### PR TITLE
bridge-utils not available on rhel8

### DIFF
--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -33,7 +33,7 @@ do
     NODE_PATH=${NODES_PATH}/$node/
     mkdir -p ${NODE_PATH}
     oc exec -it $pod -n node-gather -- ip a >> $NODE_PATH/ip.txt
-    oc exec -it $pod -n node-gather -- brctl show >> $NODE_PATH/bridge
+    oc exec -it $pod -n node-gather -- ip -o link show type bridge >> $NODE_PATH/bridge
 
     for i in $(oc exec -it $pod -n node-gather -- ls /host/sys/bus/pci/devices/);
     do

--- a/node-gather/Dockerfile
+++ b/node-gather/Dockerfile
@@ -1,3 +1,3 @@
 FROM centos:7
 
-RUN yum update -y && yum install iproute tcpdump openvswitch bridge-utils pciutils util-linux -y && yum clean all
+RUN yum update -y && yum install iproute tcpdump openvswitch pciutils util-linux -y && yum clean all


### PR DESCRIPTION
brctl is not available due to bridge-utils being deprecated. Suggested replacement is `bridge link` from iproute which is already used in the container.