### PR TITLE
Remove openvswitch dependency

### DIFF
--- a/node-gather/Dockerfile
+++ b/node-gather/Dockerfile
@@ -1,3 +1,3 @@
 FROM centos:7
 
-RUN yum update -y && yum install iproute tcpdump openvswitch pciutils util-linux -y && yum clean all
+RUN yum update -y && yum install iproute tcpdump pciutils util-linux -y && yum clean all


### PR DESCRIPTION
Since OVS logs and configuration are collected by openshift-must-gather,
we can remove this dependency from kubevirt must-gather.