### PR TITLE
Gather ImageStreamTags

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -33,6 +33,9 @@ resources+=(datavolumes)
 # NodeNetworkState
 resources+=(nodenetworkstates)
 
+# ImageStreamTag
+resources+=(istag)
+
 # Run the collection of resources using must-gather
 for resource in ${resources[@]}; do
   /usr/bin/openshift-must-gather inspect --all-namespaces ${resource}


### PR DESCRIPTION
The PR gathers the ImageStream data as requested [here](https://projects.engineering.redhat.com/browse/OSBS-7820?focusedCommentId=1693239&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1693239)
Quote:

> As a quality engineer, I am testing a complex product on a pre-deployed cluster. I can use podman to tell which image digest is running on my node. I would like to look it up somewhere (say, in brewweb) and find the NVR of the build to which it belongs, who built it and when.