### PR TITLE
Gather namespace cluster-network-addons

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -7,7 +7,7 @@ resources=()
 resources+=(ns/openshift-cnv ns/kubevirt-hyperconverged ns/openshift-operator-lifecycle-manager ns/openshift-marketplace)
 
 # KubeVirt network related namespaces
-resources+=(ns/kubemacpool-system ns/linux-bridge ns/openshift-sdn ns/cluster-network-addons-operator ns/nmstate ns/sriov)
+resources+=(ns/cluster-network-addons ns/openshift-sdn ns/sriov)
 
 # KubeVirt Web UI namespaces
 resources+=(ns/kubevirt-web-ui)


### PR DESCRIPTION
Preparing for patch:
https://github.com/kubevirt/cluster-network-addons-operator/pull/233
As a second step we should remove the obsoleted namespaces.