### PR TITLE
Changed how packagemanifests are gathered

### DIFF
--- a/collection-scripts/gather_hco
+++ b/collection-scripts/gather_hco
@@ -9,11 +9,7 @@ NS=openshift-cnv
 
 mkdir -p ${NAMESPACE_PATH}/${NS}
 
-for name in $(oc get packagemanifest -n $NS -o=custom-columns=NAME:.metadata.name --no-headers)
-do
-    oc get packagemanifest $name -n $NS -o yaml >> ${NAMESPACE_PATH}/${NS}/packagemanifests
-    echo '---------------' >> ${NAMESPACE_PATH}/${NS}/packagemanifests
-done
+oc get packagemanifest -n $NS -o yaml >>${NAMESPACE_PATH}/${NS}/packagemanifests
 
 for name in $(oc get subscriptions -n $NS -o=custom-columns=NAME:.metadata.name --no-headers)
 do


### PR DESCRIPTION
Gathering the packages one by one takes a long time which can cause must-gather to time out. This way is much faster.