### PR TITLE
Made passing a MUST_GATHER_IMAGE mandatory and documented usage of it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 IMAGE_REGISTRY ?= quay.io
-MUST_GATHER_IMAGE ?= kubevirt/must-gather
 IMAGE_TAG ?= latest
+
+# MUST_GATHER_IMAGE needs to be passed explicitly to avoid accidentally pushing to kubevirt/must-gather
+ifndef MUST_GATHER_IMAGE
+$(error MUST_GATHER_IMAGE is not set.)
+endif
 
 build: docker-build docker-push
 

--- a/README.md
+++ b/README.md
@@ -21,3 +21,20 @@ You will get a dump of:
 
 In order to get data about other parts of the cluster (not specific to KubeVirt) you should
 run `oc adm must-gather` (without passing a custom image). Run `oc adm must-gather -h` to see more options.
+
+### Development
+You can build the image locally using the Dockerfile included.
+
+A `makefile` is also provided. To use it, you must pass a repository via the command-line using the variable `MUST_GATHER_IMAGE`.
+You can also specify the registry using the variable `IMAGE_REGISTRY` (default is [quay.io](https://quay.io)) and the tag via `IMAGE_TAG` (default is `latest`).
+
+The targets for `make` are as follows:
+- `build`: builds the image with the supplied name and pushes it
+- `docker-build`: builds the image but does not push it
+- `docker-push`: pushes an already-built image
+
+For example:
+```sh
+make build MUST_GATHER_IMAGE=kubevirt/must-gather
+```
+would build the local repository as `quay.io/kubevirt/must-gather:latest` and then push it.


### PR DESCRIPTION
`MUST_GATHER_IMAGE` should be required for running `make` to prevent accidental pushes to `quay.io/kubevirt/must-gather` by a user that has permissions to do so. In addition, in order to ensure that this functionality is documented, added a Development section to the README.md.

Signed-off-by: Avram Levitter <alevitte@redhat.com>