### PR TITLE
fix sriov operator namespace

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -7,7 +7,7 @@ resources=()
 resources+=(ns/openshift-cnv ns/kubevirt-hyperconverged ns/openshift-operator-lifecycle-manager ns/openshift-marketplace)
 
 # KubeVirt network related namespaces
-resources+=(ns/cluster-network-addons ns/openshift-sdn ns/sriov-network-operator)
+resources+=(ns/cluster-network-addons ns/openshift-sdn ns/openshift-sriov-network-operator)
 
 # KubeVirt Web UI namespaces
 resources+=(ns/kubevirt-web-ui)


### PR DESCRIPTION
SR-IOV network operator namepace has changed from 
`sriov-network-operator` to `openshift-sriov-network-operator`
since ocp 4.3 release.