### PR TITLE
Build on PR, push on merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ jobs:
   include:
   - stage: Build
     name: Build
+    if: type = pull_request
+    script:
+    - make docker-build MUST_GATHER_IMAGE=kubevirt/must-gather
+  - stage: Push
+    name: Push
+    if: type = push
     script:
     - echo $QUAY_PASSWORD | docker login -u $QUAY_USERNAME --password-stdin quay.io
     - make build MUST_GATHER_IMAGE=kubevirt/must-gather


### PR DESCRIPTION
When pushing a PR for review, travis should attempt to build an image
but shouldn't push it to quay.io/kubevirt/must-gather.

Pushing an image should be done only on merge.

Fixes #66

Signed-off-by: Moti Asayag <masayag@redhat.com>