### PR TITLE
Improved output for nodes, images and v2v

### DIFF
--- a/collection-scripts/gather_images
+++ b/collection-scripts/gather_images
@@ -10,6 +10,7 @@ NAMESPACE_PATH=${BASE_COLLECTION_PATH}/namespaces
 mkdir -p ${IMAGES_PATH}
 for name in $(oc get image -o=custom-columns=NAME:.metadata.name --no-headers)
 do
+    echo "Gathering image $name"
     oc get image $name -o yaml >> ${IMAGES_PATH}/images
     echo '---------------' >> ${IMAGES_PATH}/images
 done
@@ -19,6 +20,7 @@ do
     IFS=$' '
     read namespace name <<< $line
     IFS=$'\n'
+    echo "Gathering imagestream $namespace/$name"
     mkdir -p ${NAMESPACE_PATH}/${namespace}
     oc get imagestream ${name} -n ${namespace} -o yaml >> ${NAMESPACE_PATH}/${namespace}/imagestreams
     echo '---------------' >> ${NAMESPACE_PATH}/${namespace}/imagestreams
@@ -29,6 +31,7 @@ do
     IFS=$' '
     read namespace name <<< $line
     IFS=$'\n'
+    echo "Gathering imagestreamtag $namespace/$name"
     mkdir -p ${NAMESPACE_PATH}/${namespace}
     oc get imagestreamtag ${name} -n ${namespace} -o yaml >> ${NAMESPACE_PATH}/${namespace}/imagestreamtags
     echo '---------------' >> ${NAMESPACE_PATH}/${namespace}/imagestreamtags

--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -43,12 +43,16 @@ do
     echo "Failed to collect node-gather data from node ${line} due to pod scheduling failure." >> ${NODES_PATH}/skipped_nodes.txt
 done
 
-for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n node-gather)
-do
+gather_single_pod() {
+    line="$1"
+
     node=$(echo $line | awk -F ' ' '{print $1}')
     pod=$(echo $line | awk -F ' ' '{print $2}')
     NODE_PATH=${NODES_PATH}/$node
     mkdir -p ${NODE_PATH}
+
+    echo "$pod - Gathering node data"
+
     oc exec $pod -n node-gather -- ip a 2>/dev/null >> $NODE_PATH/ip.txt
     oc exec $pod -n node-gather -- ip -o link show type bridge 2>/dev/null >> $NODE_PATH/bridge
     oc exec $pod -n node-gather -- bridge -j vlan show 2>/dev/null >> $NODE_PATH/vlan
@@ -60,17 +64,8 @@ do
         oc exec $pod -n node-gather -- nft list table $family $table 2>/dev/null > "$NODE_PATH/nft-${family}-${table}"
     done
 
-    for i in $(oc exec $pod -n node-gather -- ls /host/sys/bus/pci/devices/ 2>/dev/null);
-    do
-        if [ $(oc exec $pod -n node-gather -- test -e /host/sys/bus/pci/devices/$i/sriov_numvfs 2>/dev/null && echo 1 || echo 0) -eq 1 ];
-        then
-            echo "sriov_numvfs on dev $i: $(oc exec $pod -n node-gather -- cat /host/sys/bus/pci/devices/$i/sriov_numvfs 2>/dev/null)"  >> $NODE_PATH/sys_sriov_numvfs
-        fi
-        if [ $(oc exec $pod -n node-gather -- test -e /host/sys/bus/pci/devices/$i/sriov_totalvfs 2>/dev/null && echo 1 || echo 0) -eq 1 ];
-        then
-            echo "sriov_numvfs on dev $i: $(oc exec $pod -n node-gather -- cat /host/sys/bus/pci/devices/$i/sriov_totalvfs 2>/dev/null)"  >> $NODE_PATH/sys_sriov_totalvfs
-        fi
-    done
+    oc exec $pod -n node-gather -- /bin/bash -c 'for dev in /host/sys/bus/pci/devices/*; do if [[ -e $dev/sriov_numvfs ]]; then echo "sriov_numvfs on dev ${dev##*/}: $(cat $dev/sriov_numvfs)"; fi; done' >> $NODE_PATH/sys_sriov_numvfs
+    oc exec $pod -n node-gather -- /bin/bash -c 'for dev in /host/sys/bus/pci/devices/*; do if [[ -e $dev/sriov_totalvfs ]]; then echo "sriov_totalvfs on dev ${dev##*/}: $(cat $dev/sriov_totalvfs)"; fi; done' >> $NODE_PATH/sys_sriov_totalvfs
 
     oc exec $pod -n node-gather -- [ -d /host/opt/cni/bin ] 2>/dev/null
     if [[ $? -eq 0 ]]; then
@@ -104,7 +99,14 @@ do
         oc cp $pod:/host/etc/pcidp/config.json $NODE_PATH/pcidp_config.json -n node-gather 2>/dev/null
     fi
 
+}
+
+for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n node-gather)
+do
+    gather_single_pod "$line" &
 done
+
+wait
 
 # Collect journal logs for specified units for all nodes
 NODE_UNITS=(NetworkManager kubelet)

--- a/collection-scripts/gather_v2v
+++ b/collection-scripts/gather_v2v
@@ -9,15 +9,11 @@ do
 
     for pod in $(oc get pods -n $ns --no-headers -o=custom-columns=NAME:.metadata.name 2>/dev/null)
     do
-        if ! expr $pod : 'kubevirt-v2v-conversion-*' && ! expr $pod : 'vm-import-*' >/dev/null
-        then
-            continue
+        if [[ $pod == kubevirt-v2v-conversion-* || $pod == vm-import-* ]]; then
+            pod_collection_path=$ns_collection_path/$pod
+            mkdir -p $pod_collection_path
+            /usr/bin/oc adm inspect --dest-dir must-gather -n $ns pod/$pod
+            oc logs $pod -n $ns > $ns_collection_path/$pod.log
         fi
-
-        pod_collection_path=$ns_collection_path/$pod
-        mkdir -p $pod_collection_path
-
-        /usr/bin/oc adm inspect --dest-dir must-gather -n $ns pod/$pod
-        oc logs $pod -n $ns > $ns_collection_path/$pod.log
     done
 done


### PR DESCRIPTION
The must-gather command expects data to be printed out to the pod's log,
and if nothing is received within a given period of time, it will exit
on timeout.  If no data (expecting a newline) is received in the read
call, it may exit with unexpected EOF as well.

To overcome this, this patch speeds up the gathering of node data mainly
by moving all the sriov detection to a single oc exec call, and by
parallelizing gather_nodes.  It also adds some verbosity to
gather_images and removes the expr calls in v2v which displayed lines
containing the result of the expression.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>