### PR TITLE
nodes: add verbosity when waiting for daemonset

### DIFF
--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -34,8 +34,11 @@ oc create -f $DAEMONSET_MANIFEST
 
 COUNTER=0
 until check_node_gather_pods_ready || [ $COUNTER -eq 300 ]; do
-   (( COUNTER++ ))
-   sleep 1
+    if [[ $(( COUNTER % 20 )) == 0 ]]; then
+        echo "Waiting for node-gather-daemonset to be ready"
+    fi
+    (( COUNTER++ ))
+    sleep 1
 done
 
 for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName --no-headers --field-selector=status.phase!=Running -n node-gather)


### PR DESCRIPTION
must-gather will fail on unexpected EOF when not receiving data from the
pod's log after ~60 seconds.
This patch will print a line while waiting for the node daemonset to be
ready every 10 seconds.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>