### PR TITLE
must-gather: fix the ds readiness check

### DIFF
--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -7,7 +7,7 @@ check_node_gather_pods_ready() {
     read desired ready <<< $line
     IFS=$'\n'
 
-    if [[ $ready -eq $desired ]]
+    if [[ "$desired" != "0" ]] && [[ "$ready" == "$desired" ]]
     then
        return 0
     else


### PR DESCRIPTION
This is the same fix we committed recently here: https://github.com/openshift-kni/performance-addon-operators/pull/296
The must-gather logic we added for performance-addon-operator is
borrowed from the code here, so the fix may be relevant as well.

Signed-off-by: Francesco Romani <fromani@redhat.com>