### PR TITLE
Updated the container image jsonpath

### DIFF
--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -23,8 +23,8 @@ mkdir -p ${NODES_PATH}
 CRD_MANIFEST="/etc/node-gather-crd.yaml"
 DAEMONSET_MANIFEST="/etc/node-gather-ds.yaml"
 NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-POD_NAME=$(oc get pods --field-selector=status.podIP=$(hostname -I) -n $NAMESPACE -o'custom-columns=name:metadata.name' --no-headers)
-MUST_GATHER_IMAGE=$(oc get pod -n $NAMESPACE $POD_NAME -o jsonpath="{.spec.initContainers[0].image}")
+POD_NAME=$(oc get pods -l app=must-gather -n $NAMESPACE -o'custom-columns=name:metadata.name' --no-headers)
+MUST_GATHER_IMAGE=$(oc get pod -n $NAMESPACE $POD_NAME -o jsonpath="{.spec.containers[0].image}")
 
 sed -i -e "s#MUST_GATHER_IMAGE#$MUST_GATHER_IMAGE#" $DAEMONSET_MANIFEST
 


### PR DESCRIPTION
oc must-gather does not use an init container anymore, so we have to
update the jsonpath to the new format, otherwise gathering data from
nodes will not work

Fixes bz#1848269

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>