### PR TITLE
gather more nmstate-related objects

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -34,7 +34,7 @@ resources+=(ns/cdi)
 resources+=(datavolumes)
 
 # NodeNetworkState
-resources+=(nodenetworkstates)
+resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies)
 
 # ImageStreamTag
 resources+=(istag)


### PR DESCRIPTION
To understand why node network configuration fails, we should collect
policies and their enactments.

```release-note
Gather nmstate-releated NodeNetworkConfigurationPolicies and Enactments
```

Signed-off-by: Dan Kenigsberg <danken@redhat.com>