### PR TITLE
virtualmachines are sorted to custom and template-based

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -15,9 +15,6 @@ resources+=(ns/kubevirt-web-ui)
 # HCO
 resources+=(catalogsource clusterserviceversion)
 
-# VM
-resources+=(virtualmachines)
-
 # VMI
 resources+=(virtualmachineinstances virtualmachineinstancereplicasets virtualmachineinstancepresets virtualmachineinstancemigrations)
 
@@ -48,6 +45,9 @@ for resource in "${resources[@]}"; do
     echo "Inspecting resource ${resource}..."
     /usr/bin/oc adm inspect --dest-dir must-gather --all-namespaces "${resource}" &> /dev/null
 done
+
+# VM
+/usr/bin/gather_virtualmachines
 
 # Collect HCO details (first, because it's there before anything else)
 /usr/bin/gather_hco

--- a/collection-scripts/gather_virtualmachines
+++ b/collection-scripts/gather_virtualmachines
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+BASE_COLLECTION_PATH="/must-gather"
+
+
+for i in $(/usr/bin/oc get virtualmachines --all-namespaces --no-headers | awk '{print $1}')
+do
+  resources+=("$i")
+done
+
+for resource in "${resources[@]}"; do
+  for vm in $(/usr/bin/oc get virtualmachine -n "$resource" --no-headers |  awk -F ' ' '{print $1}'); do
+    vm_path="${BASE_COLLECTION_PATH}/namespaces/${resource}/kubevirt.io/virtualmachines"
+
+    if [[ $(/usr/bin/oc get virtualmachine "$vm" -o json -n "$resource" | grep -c "vm.kubevirt.io/template") -gt 0 ]]; then
+      vm_path="$vm_path/template-based"
+    else
+      vm_path="$vm_path/custom"
+    fi
+    mkdir -p "${vm_path}"
+
+    /usr/bin/oc get virtualmachine "$vm" -o yaml -n "$resource" > "$vm_path/$vm.yaml"
+  done
+done
+
+exit 0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes behaviuor how are yaml files of virtualmachines
saved. Previously virtualmachines were save to one folder. Now
virtualmachines are saved into separate folders based on if they
were created from common template or if they are custom created.

**Fixes**: https://bugzilla.redhat.com/show_bug.cgi?id=1966137

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>