### PR TITLE
Allow overriding the CNV namespace for community deploymet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM quay.io/openshift/origin-must-gather:4.8.0 as builder
 
 FROM quay.io/centos/centos:8
 
+ENV INSTALLATION_NAMESPACE kubevirt-hyperconverged
+
 # For gathering data from nodes
 RUN dnf update -y && dnf install iproute tcpdump pciutils util-linux nftables rsync -y && dnf clean all
 

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}
+
 # Resource list
 resources=()
 
 # KubeVirt HCO related namespaces
-resources+=(ns/openshift-cnv ns/kubevirt-hyperconverged ns/openshift-operator-lifecycle-manager ns/openshift-marketplace)
+resources+=("ns/${INSTALLATION_NAMESPACE}" ns/kubevirt-hyperconverged ns/openshift-operator-lifecycle-manager ns/openshift-marketplace)
 
 # KubeVirt network related namespaces
 resources+=(ns/cluster-network-addons ns/openshift-sdn ns/sriov-network-operator)

--- a/collection-scripts/gather_hco
+++ b/collection-scripts/gather_hco
@@ -5,20 +5,20 @@ IFS=$'\n'
 BASE_COLLECTION_PATH="/must-gather"
 
 NAMESPACE_PATH=${BASE_COLLECTION_PATH}/namespaces
-NS=openshift-cnv
+INSTALLATION_NAMESPACE="${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}"
 
-mkdir -p ${NAMESPACE_PATH}/${NS}
+mkdir -p "${NAMESPACE_PATH}/${INSTALLATION_NAMESPACE}"
 
-oc get packagemanifest -n $NS -o yaml >>${NAMESPACE_PATH}/${NS}/packagemanifests
+oc get packagemanifest -n "${INSTALLATION_NAMESPACE}" -o yaml >> "${NAMESPACE_PATH}/${INSTALLATION_NAMESPACE}/packagemanifests"
 
-for name in $(oc get subscriptions -n $NS -o=custom-columns=NAME:.metadata.name --no-headers)
+for name in $(oc get subscriptions -n "${INSTALLATION_NAMESPACE}" -o=custom-columns=NAME:.metadata.name --no-headers)
 do
-    oc get subscription "$name" -n "$NS" -o yaml >> "${NAMESPACE_PATH}/${NS}/subscriptions"
-    echo '---------------' >> "${NAMESPACE_PATH}/${NS}/subscriptions"
+    oc get subscription "$name" -n "${INSTALLATION_NAMESPACE}" -o yaml >> "${NAMESPACE_PATH}/${INSTALLATION_NAMESPACE}/subscriptions"
+    echo '---------------' >> "${NAMESPACE_PATH}/${INSTALLATION_NAMESPACE}/subscriptions"
 done
 
-for name in $(oc get installplan -n $NS -o=custom-columns=NAME:.metadata.name --no-headers)
+for name in $(oc get installplan -n "${INSTALLATION_NAMESPACE}" -o=custom-columns=NAME:.metadata.name --no-headers)
 do
-    oc get installplan "$name" -n "$NS" -o yaml >> "${NAMESPACE_PATH}/${NS}/installplans"
-    echo '---------------' >> "${NAMESPACE_PATH}/${NS}/installplans"
+    oc get installplan "$name" -n "${INSTALLATION_NAMESPACE}" -o yaml >> "${NAMESPACE_PATH}/${INSTALLATION_NAMESPACE}/installplans"
+    echo '---------------' >> "${NAMESPACE_PATH}/${INSTALLATION_NAMESPACE}/installplans"
 done


### PR DESCRIPTION
The installation namespace is hardcoded. This PR allows overriding it by setting another value in the Dockerfile.
The default namespace is `kubevirt-hyperconverged`.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
None
```