### PR TITLE
Don't gather kubelet logs

### DIFF
--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -108,7 +108,7 @@ done
 wait
 
 # Collect journal logs for specified units for all nodes
-NODE_UNITS=(NetworkManager kubelet)
+NODE_UNITS=(NetworkManager)
 for NODE in $(oc get nodes --no-headers -o custom-columns=':metadata.name'); do
     NODE_PATH=${NODES_PATH}/$NODE
     mkdir -p "${NODE_PATH}"


### PR DESCRIPTION
In order to reduce the size of the gathered data, this PR drop the gathering of the kubelet logs. worker nodes' kubelet logs are (by far) the largest files collected, and it's possible to collect them using the OCP mustgather:

```bash
oc adm must-gather -- /usr/bin/gather_service_logs worker
```

**Release note**:
```release-note
Don't gather kubelet logs to consistently reduce log size
```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>