### PR TITLE
Add targeted gathering to collect VM information

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,31 @@ You will get a dump of:
 - All namespaces (and their children objects) that belong to any KubeVirt resources
 - All KubeVirt CRD's definitions
 - All namspaces that contains VMs
-- All VMs definition
+
+By default, the VMs definitions won't be included, but only the VM Instances' custom resources.
 
 In order to get data about other parts of the cluster (not specific to KubeVirt) you should
 run `oc adm must-gather` (without passing a custom image). Run `oc adm must-gather -h` to see more options.
+
+#### Targeted gathering
+To collect the VM information, call directly the `gather_vms_details` command:
+```sh
+oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather_vms_details
+```
+
+The `gather_vms_details` command supports targeted gathering. By specifying a namespace, the command will only 
+collect the VMs in this namespace. For example, collecting all the VM information in namespace "vm1":
+```sh
+oc adm must-gather --image=quay.io/kubevirt/must-gather -- NS=ns1 /usr/bin/gather_vms_details
+```
+
+By specifying the VM name in addition to the namespace, the `gather_vms_details` command will only collect the specific
+VM information. For example, collecting the information of a specific VM called "testvm" in namespace "vm1":
+```sh
+oc adm must-gather --image=quay.io/kubevirt/must-gather -- NS=ns1 VM=testvm /usr/bin/gather_vms_details
+```
+***Note***: When collecting information for a specific VM, you must specify the namespace as well. Without the namespace,
+the `gather_vms_details` command exits and prints an error message.
 
 ### Development
 You can build the image locally using the Dockerfile included.

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -6,7 +6,7 @@ INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}
 resources=()
 
 # KubeVirt HCO related namespaces
-resources+=("ns/${INSTALLATION_NAMESPACE}" ns/kubevirt-hyperconverged ns/openshift-operator-lifecycle-manager ns/openshift-marketplace)
+resources+=("ns/${INSTALLATION_NAMESPACE}" ns/openshift-operator-lifecycle-manager ns/openshift-marketplace)
 
 # KubeVirt network related namespaces
 resources+=(ns/cluster-network-addons ns/openshift-sdn ns/sriov-network-operator)
@@ -18,7 +18,7 @@ resources+=(ns/kubevirt-web-ui)
 resources+=(catalogsource clusterserviceversion)
 
 # VMI
-resources+=(virtualmachineinstances virtualmachineinstancereplicasets virtualmachineinstancepresets virtualmachineinstancemigrations)
+resources+=(virtualmachineinstancereplicasets virtualmachineinstancepresets virtualmachineinstancemigrations)
 
 # v2v
 resources+=(v2vvmwares virtualmachineimports)
@@ -43,13 +43,11 @@ resources+=(nodes)
 resources+=(machines)
 
 # Run the collection of resources using must-gather
-for resource in "${resources[@]}"; do
-    echo "Inspecting resource ${resource}..."
-    /usr/bin/oc adm inspect --dest-dir must-gather --all-namespaces "${resource}" &> /dev/null
-done
+echo ${resources[@]} | tr ' ' '\n' | xargs -t -I{} -P 5 sh -c 'echo "inspecting $1" && oc adm inspect --dest-dir must-gather --all-namespaces $1' -- {}
 
-# VM
-/usr/bin/gather_virtualmachines
+# read VMIs, but not in parallel to other reads
+echo "inspecting virtualmachineinstances"
+oc adm inspect --dest-dir must-gather --all-namespaces virtualmachineinstances
 
 # Collect HCO details (first, because it's there before anything else)
 /usr/bin/gather_hco
@@ -62,12 +60,6 @@ done
 
 # Collect the apiservices
 /usr/bin/gather_apiservices
-
-# Collect namespaces that contains VMs
-/usr/bin/gather_vms_namespaces
-
-# Collect VMs details
-/usr/bin/gather_vms_details
 
 # Collect SSP details
 /usr/bin/gather_ssp

--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -1,15 +1,17 @@
 #!/bin/bash
+
 BASE_COLLECTION_PATH="/must-gather"
 
-for i in $(/usr/bin/oc get pod --all-namespaces -l kubevirt.io=virt-launcher --no-headers | awk '{print $1 "_" $2}')
-do
-  ocproject=$(echo "$i" | awk -F_ '{print $1}')
-  ocvm=$(echo "$i" | awk -F_ '{print $2}')
-  vm_collection_path=${BASE_COLLECTION_PATH}/namespaces/${ocproject}/vms
-
+function gather_vm_info() {
+  ocproject=$1
+  ocvm=$2
+  vmname=$3
+  vm_collection_path=${BASE_COLLECTION_PATH}/namespaces/${ocproject}/vms/${vmname}
   mkdir -p "${vm_collection_path}"
 
-  vmname=$(echo "${ocvm}" 2>/dev/null | cut -d'-' -f3- | sed "s/-[^-]*$//")
+  /usr/bin/oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" -n $ocproject pod $ocvm
+  /usr/bin/oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" -n $ocproject virtualmachines $vmname
+  /usr/bin/oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" -n $ocproject virtualmachineinstances $vmname
 
   # VM : dumpxml
   /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- virsh dumpxml "${ocproject}_${vmname}" > "${vm_collection_path}/${ocvm}.dumpxml.xml"
@@ -51,7 +53,40 @@ do
     echo "###################################"
     /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- iptables -t nat -L 2>/dev/null
   } > "${vm_collection_path}/${ocvm}.iptables.txt"
+}
 
-done
+if [[ -n $NS ]]; then
+  NS=${NS} /usr/bin/gather_vms_namespaces
+
+  if [[ -n $VM ]]; then
+    POD=$(oc get pod -n ${NS} --no-headers -o 'custom-columns=name:metadata.name' | grep -E "virt-launcher-${VM}-[^-]+$")
+    gather_vm_info ${NS} ${POD} ${VM}
+  else
+    for i in $(/usr/bin/oc get pod -n $NS -l kubevirt.io=virt-launcher --no-headers | awk '{print $1 "_" $2}')
+    do
+      ocvm=$(echo "$i" | awk -F_ '{print $1}')
+      vmname=$(echo "${ocvm}" 2>/dev/null | cut -d'-' -f3- | sed "s/-[^-]*$//")
+
+      gather_vm_info ${NS} ${ocvm} ${vmname}
+    done
+  fi
+
+else
+  /usr/bin/gather_vms_namespaces
+
+  if [[ -n $VM ]]; then
+    echo "ERROR: can't collect information for a specific VM without specifying the namespace"
+    exit 1
+  fi
+
+  for i in $(/usr/bin/oc get pod --all-namespaces -l kubevirt.io=virt-launcher --no-headers | awk '{print $1 "_" $2}')
+  do
+    ocproject=$(echo "$i" | awk -F_ '{print $1}')
+    ocvm=$(echo "$i" | awk -F_ '{print $2}')
+    vmname=$(echo "${ocvm}" 2>/dev/null | cut -d'-' -f3- | sed "s/-[^-]*$//")
+
+    gather_vm_info ${ocproject} ${ocvm} ${vmname}
+  done
+fi
 
 exit 0

--- a/collection-scripts/gather_vms_namespaces
+++ b/collection-scripts/gather_vms_namespaces
@@ -1,16 +1,24 @@
 #!/bin/bash
 
+BASE_COLLECTION_PATH="/must-gather"
+
 # Resource list
 resources=()
 
-for i in $(/usr/bin/oc get virtualmachines --all-namespaces --no-headers | awk '{print $1}')
-do
-  resources+=("ns/$i")
-done
+if [[ -n $NS ]]; then
+  resources=("ns/$NS")
+else
+  for i in $(/usr/bin/oc get virtualmachines --all-namespaces --no-headers | awk '{print $1}')
+  do
+    resources+=("ns/$i")
+  done
+fi
+
+unique_resources=$(echo ${resources[@]} | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
 # Run the collection of resources using must-gather
-for resource in "${resources[@]}"; do
-  /usr/bin/oc adm inspect --dest-dir must-gather "${resource}"
+for resource in "${unique_resources[@]}"; do
+  /usr/bin/oc adm inspect --dest-dir ${BASE_COLLECTION_PATH} ${resource}
 done
 
 exit 0


### PR DESCRIPTION
Don't collect the VM information by default. Instead, add option to collect only VM information for all the VM in the cluster, all the VMs in a specific namespace or for a specific VM by its name.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't collect the VM information by default. Instead, add option to collect only VM information for all the VM in the cluster, all the VMs in a specific namespace or for a specific VM by its name.
```

