### PR TITLE
test: try to run CI tests defining 200 VMs

### DIFF
--- a/automation/create_workloads.sh
+++ b/automation/create_workloads.sh
@@ -4,8 +4,8 @@ set -ex
 
 CMD=oc
 
-# create 100 VMs
-for ns in {001..005}; do
+# create 200 VMs
+for ns in {001..010}; do
   sed "s#__NS__#${ns}#g" automation/ns.yaml | ${CMD} apply -f -
   for vm in {001..020}; do
     sed -e "s#__NS__#${ns}#g" -e "s|##VM##|${vm}|g" automation/vm.yaml >> "vms_ns${ns}.yaml"


### PR DESCRIPTION
Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
run CI tests defining 200 VMs
```

