### PR TITLE
Add two more option to gather VM information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-KubeVirt must-gather
-=================
+# KubeVirt must-gather
 
 `must-gather` is a tool built on top of [OpenShift must-gather](https://github.com/openshift/must-gather)
 that expands its capabilities to gather KubeVirt information.
 
-### Usage
+## Usage
 ```sh
 oc adm must-gather --image=quay.io/kubevirt/must-gather
 ```
@@ -22,35 +21,100 @@ By default, the VMs definitions won't be included, but only the VM Instances' cu
 In order to get data about other parts of the cluster (not specific to KubeVirt) you should
 run `oc adm must-gather` (without passing a custom image). Run `oc adm must-gather -h` to see more options.
 
-#### Parallelism
+### Parallelism
 Some gathering activity can be done in parallel. Collecting resources one by one may be slow, and collecting too many 
 resources in parallel may fail. By default, 5 processes are running in parallel, and the rest of the processes are 
 waiting for running processes to complete. It is possible to change this default number of processes by setting the
 `PROS` environment variable, but then, the default command must be specified as well, like this:
 
 ```sh
-oc adm must-gather --image=quay.io/kubevirt/must-gather -- PROS=7 /usr/bin/gather
+oc adm must-gather \
+   --image=quay.io/kubevirt/must-gather \
+   -- PROS=7 \
+   /usr/bin/gather
 ```
 
-#### Targeted gathering
+### Targeted gathering - VM information
+
 To collect the VM information, and all the namespaces that contains VMs call directly the `gather_vms_details` command:
 ```sh
-oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather_vms_details
+oc adm must-gather \
+   --image=quay.io/kubevirt/must-gather \
+   -- /usr/bin/gather_vms_details
 ```
 
+#### VMs in a Namespace
 The `gather_vms_details` command supports targeted gathering. By specifying a namespace, the command will only 
 collect the VMs in this namespace. For example, collecting all the VM information in namespace "vm1":
 ```sh
-oc adm must-gather --image=quay.io/kubevirt/must-gather -- NS=ns1 /usr/bin/gather_vms_details
+oc adm must-gather \
+   --image=quay.io/kubevirt/must-gather \
+   -- NS=ns1 \
+   /usr/bin/gather_vms_details
 ```
 
+#### Specific VM
 By specifying the VM name in addition to the namespace, the `gather_vms_details` command will only collect the specific
 VM information. For example, collecting the information of a specific VM called "testvm" in namespace "vm1":
 ```sh
-oc adm must-gather --image=quay.io/kubevirt/must-gather -- NS=ns1 VM=testvm /usr/bin/gather_vms_details
+oc adm must-gather \
+   --image=quay.io/kubevirt/must-gather \
+   -- NS=ns1 \
+   VM=testvm \
+   /usr/bin/gather_vms_details
 ```
 ***Note***: When collecting information for a specific VM, you must specify the namespace as well. Without the namespace,
 the `gather_vms_details` command exits and prints an error message.
+
+#### List of Specific VMs
+The `VM` environment variable can also be a comma-seperated list of VM names (without a space). For example:
+```sh
+oc adm must-gather \
+   --image=quay.io/kubevirt/must-gather \
+   -- NS=ns1 \
+   VM="testvm1,testvm34,testvm52,testvm74", \
+   /usr/bin/gather_vms_details
+```
+#### Gather VM by Regex Expression
+The `gather_vms_details` command also support gathering VM with regex expression.
+
+For example, suppose we have the following VMs in the cluster:
+```
+testvm1-1 testvm1-2 testvm1-3 testvm1-4 testvm1-5  
+testvm1-6 testvm1-7 testvm1-8 testvm1-9 testvm1-10
+testvm2-1 testvm2-2 testvm2-3 testvm2-4 testvm2-5 
+testvm2-6 testvm2-7 testvm2-8 testvm2-9 testvm2-10
+testvm3-1 testvm3-2 testvm3-3 testvm3-4 testvm3-5
+testvm3-6 testvm3-7 testvm3-8 testvm3-9 testvm3-10
+testvm4-1 testvm4-2 testvm4-3 testvm4-4 testvm4-5
+testvm4-6 testvm4-7 testvm4-8 testvm4-9 testvm4-10
+testvm5-1 testvm5-2 testvm5-3 testvm5-4 testvm5-5 
+testvm5-6 testvm5-7 testvm5-8 testvm5-9 testvm5-10
+```
+
+If we want to read only VMs that starts with testvm2, testvm3 or testvm4, and that their postfix number is odd, we can use this regex expression to for that: `^testvm[2-4]-[0-9]*[1,3,5,7,9]$`.
+
+Here is how to use it in the `gather_vms_details` command, to search VMs by regex:
+```sh
+oc adm must-gather \
+   --image=quay.io/kubevirt/must-gather \
+   VM_EXP="^testvm[2-4]-[0-9]*[1,3,5,7,9]$", \
+   /usr/bin/gather_vms_details
+```
+
+Here is how to use it in the `gather_vms_details` command, to search VMs by regex in the `ns1` namespace:
+```sh
+oc adm must-gather \
+   --image=quay.io/kubevirt/must-gather \
+   -- NS=ns1 \
+   VM_EXP="^testvm[2-4]-[0-9]*[1,3,5,7,9]$", \
+   /usr/bin/gather_vms_details
+```
+
+***Note***: When collecting information using the `VM` variable, the command will ignore the `VM_EPR` variable. Do not use both of them together.
+
+
+### Targeted gathering - Images information
 
 It is possible to collect image, image-stream and image-stream-tags information using the `gather_images` command:
 ```sh
@@ -67,7 +131,7 @@ Or
 oc adm must-gather --image=quay.io/kubevirt/must-gather -- PROS=3 /usr/bin/gather_images
 ```
 
-### Development
+## Development
 You can build the image locally using the Dockerfile included.
 
 A `makefile` is also provided. To use it, you must pass a repository via the command-line using the variable `MUST_GATHER_IMAGE`.

--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
+export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+export PROS=${PROS:-5}
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 function gather_vm_info() {
@@ -64,38 +64,43 @@ function gather_vm_by_pod_name() {
   ocvm=$(echo "$pod" | awk -F_ '{print $2}')
   vmname=$(echo "${ocvm}" 2>/dev/null | cut -d'-' -f3- | sed "s/-[^-]*$//")
 
+  if [[ -n ${VM_EXP} ]]; then
+    if [[ ! "${vmname}" =~ ${VM_EXP} ]]; then
+      return 0
+    fi
+  fi
+  echo "inspecting ${vmname}"
   gather_vm_info ${ocproject} ${ocvm} ${vmname}
 }
 
+export -f gather_vm_by_pod_name
+export -f gather_vm_info
+
+${DIR_NAME}/gather_vms_namespaces
+
 if [[ -n $NS ]]; then
-  BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH} NS=${NS} ${DIR_NAME}/gather_vms_namespaces
-
-  if [[ -n $VM ]]; then
-    POD=$(oc get pod -n ${NS} --no-headers -o 'custom-columns=name:metadata.name' | grep -E "virt-launcher-${VM}-[^-]+$")
-    gather_vm_info ${NS} ${POD} ${VM}
-  else
-    for i in $(/usr/bin/oc get pod -n $NS -l kubevirt.io=virt-launcher --no-headers | awk '{print $1 "_" $2}')
-    do
-      ocvm=$(echo "$i" | awk -F_ '{print $1}')
-      vmname=$(echo "${ocvm}" 2>/dev/null | cut -d'-' -f3- | sed "s/-[^-]*$//")
-
-      gather_vm_info ${NS} ${ocvm} ${vmname}
+  if [[ -n ${VM} ]]; then
+    VMS=($(echo ${VM} | sed "s|,| |g"))
+    PODS=($(oc get pod -n ${NS} --no-headers -o 'custom-columns=name:metadata.name'))
+    for vm in ${VMS[@]}; do
+      POD=$(echo ${PODS[@]} | tr ' ' '\n' | grep -E "virt-launcher-${vm}-[^-]+$")
+      gather_vm_info ${NS} ${POD} ${vm}
     done
+
+  else
+    PODS=$(/usr/bin/oc get pod -n $NS -l kubevirt.io=virt-launcher --no-headers -o custom-columns=NAME:.metadata.name)
+    echo ${PODS[@]} | tr ' ' '\n' | xargs -t -P ${PROS} --max-args=1 -I{} sh -c 'gather_vm_by_pod_name $1' -- ${NS}_{}
   fi
 
 else
-  BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH} PROS=${PROS} ${DIR_NAME}/gather_vms_namespaces
-
   if [[ -n $VM ]]; then
     echo "ERROR: can't collect information for a specific VM without specifying the namespace"
     exit 1
   fi
 
-  export -f gather_vm_by_pod_name
-  export -f gather_vm_info
-  export BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH}
   PODS=$(oc get pod --all-namespaces -l kubevirt.io=virt-launcher --no-headers | awk '{print $1 "_" $2}')
   echo ${PODS[@]} | tr ' ' '\n' | xargs -P ${PROS} --max-args=1 -t -I{} sh -c 'gather_vm_by_pod_name $1' -- {}
+
 fi
 
 exit 0


### PR DESCRIPTION
1. The `VM` variable now also supports a comma-seperated list of VMs.
2. The new `VM_EXP` allows select VMs to gather their information, by a regex expression.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add two more option to gather VM information

1. The `VM` variable now also supports a comma-seperated list of VMs.
2. The new `VM_EXP` allows select VMs to gather their information, by a regex expression.
```

