### PR TITLE
[release-4.9] Improve the gather_virtualmachines script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ FROM quay.io/centos/centos:8
 ENV INSTALLATION_NAMESPACE kubevirt-hyperconverged
 
 # For gathering data from nodes
-RUN dnf update -y && dnf install iproute tcpdump pciutils util-linux nftables rsync -y && dnf clean all
+RUN dnf update -y && \
+    dnf install iproute tcpdump pciutils util-linux nftables rsync jq -y && \
+    dnf clean all && \
+    curl -L $(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | jq -r '.assets[] | select(.name == "yq_linux_amd64") | .browser_download_url') -o /usr/bin/yq && \
+    chmod +x /usr/bin/yq
 
 COPY --from=builder /usr/bin/oc /usr/bin/oc
 

--- a/automation/create_workloads.sh
+++ b/automation/create_workloads.sh
@@ -4,21 +4,20 @@ set -ex
 
 CMD=oc
 
-ANNOTATION_EXP="/^  namespace: ns.*$/a\  annotations:\n    vm.kubevirt.io/template: some-template"
+LABEL_EXP="/^  namespace: ns.*$/a\  labels:\n    vm.kubevirt.io/template: some-template"
 
 # create 100 VMs
 for ns in {001..005}; do
   sed "s#__NS__#${ns}#g" automation/ns.yaml | ${CMD} apply -f -
   for vm in {001..020}; do
+    EXP=
     n=$(echo $vm | sed "s|^0*||")
     if [[ $(($n%2)) -eq 0 ]]; then
-      sed -e "s#__NS__#${ns}#g" -e "s|##VM##|${vm}|g" -e "${ANNOTATION_EXP}" automation/vm.yaml >> "vms_ns${ns}.yaml"
-    else
-      sed -e "s#__NS__#${ns}#g" -e "s|##VM##|${vm}|g" automation/vm.yaml >> "vms_ns${ns}.yaml"
+      EXP="; ${LABEL_EXP}"
     fi
+    sed -e "s#__NS__#${ns}#g; s|##VM##|${vm}|g${EXP}" automation/vm.yaml | ${CMD} apply -f -
 
   done
-  ${CMD} apply -f "vms_ns${ns}.yaml"
 
   # start 5 VMs
   if [[ ${ns} -le 5 ]]; then

--- a/collection-scripts/gather_virtualmachines
+++ b/collection-scripts/gather_virtualmachines
@@ -1,33 +1,26 @@
-#!/bin/bash -x
+#!/bin/bash
 
-BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
 PROS=${PROS:-5}
 
-function collect_vm() {
-  vm=$1
-  ns=$2
-  ns_path=$3
-
-  if oc get -n ${ns} vm ${vm} -o jsonpath='{ .metadata.annotations }' | grep 'vm.kubevirt.io/template'; then
-    vm_path="$ns_path/template-based"
+function write_vm_to_file() {
+  item=$(echo $1 | base64 -d)
+  ns=$(echo ${item} | jq -r '.metadata.namespace')
+  ns_path="${BASE_COLLECTION_PATH}/namespaces/${ns}/kubevirt.io/virtualmachines"
+  name=$(echo ${item} | jq -r '.metadata.name')
+  echo "Writing VM ${ns}/${name}"
+  # If there is a label that starts with "vm.kubevirt.io/template", this is a template based VM
+  if echo ${item} | jq '.metadata.labels | keys | .[] | startswith("vm.kubevirt.io/template")' | jq -s | jq -e any; then
+    dir="${ns_path}/template-based/"
   else
-    vm_path="$ns_path/custom"
+    dir="${ns_path}/custom/"
   fi
-
-  mkdir -p "${vm_path}"
-
-  /usr/bin/oc get virtualmachine "$vm" -o yaml -n "$ns" > "$vm_path/$vm.yaml"
+  mkdir -p ${dir}
+  echo ${item} | yq eval -P - > "${dir}/${name}.yaml"
 }
 
-export -f collect_vm
+export -f write_vm_to_file
 
-namespaces=($(/usr/bin/oc get virtualmachines --all-namespaces --no-headers | awk '{print $1}' | uniq))
-
-for ns in "${namespaces[@]}"; do
-  ns_path="${BASE_COLLECTION_PATH}/namespaces/${ns}/kubevirt.io/virtualmachines"
-
-  vms=$(/usr/bin/oc get virtualmachine -n "${ns}" --no-headers -o custom-columns=NAME:.metadata.name)
-  echo ${vms[@]} | tr ' ' '\n' | xargs -t -P ${PROS} --max-args=1 -I{} sh -c 'collect_vm $1 $2 $3' -- {} "${ns}" "${ns_path}"
-done
+/usr/bin/oc get virtualmachine -A -o json | jq -r '.items[] | @base64' | xargs -P ${PROS} --max-args=1 -I{} sh -c 'write_vm_to_file  $1' -- {}
 
 exit 0

--- a/tests/validate_must_gather_test.go
+++ b/tests/validate_must_gather_test.go
@@ -326,7 +326,12 @@ func getDataDir() (string, error) {
 		return "", err
 	}
 
-	outputDir := path.Join(wd, "must-gather-output")
+	mgOutputDir, found := os.LookupEnv("MG_OUTPUT_DIR")
+	if !found {
+		mgOutputDir = "must-gather-output"
+	}
+
+	outputDir := path.Join(wd, mgOutputDir)
 
 	files, err := os.ReadDir(outputDir)
 	if err != nil {


### PR DESCRIPTION
Improve the gather_virtualmachines script by reducing the number of calls to the API-Server from 2 per VM, to 1 single call to get them all.

Fix bug in splitting VM yamls to custem and template based directory (BZ 1966137).

Allow writing to custom output in CI tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix BZ 1966137
```

