### PR TITLE
nftables: Fix collecting nftables from nodes

### DIFF
--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -66,12 +66,7 @@ function gather_single_pod() {
     oc exec "$pod" -n node-gather -- ip -o link show type bridge 2>/dev/null >> "$NODE_PATH/bridge"
     oc exec "$pod" -n node-gather -- bridge -j vlan show 2>/dev/null >> "$NODE_PATH/vlan"
 
-    for i in $(oc exec "$pod" -n node-gather -- nft list tables 2>/dev/null);
-    do
-        family=$(echo "$i" | awk -F ' ' '{print $2}' | sed 's/\r//')
-        table=$(echo "$i" | awk -F ' ' '{print $3}' | sed 's/\r//')
-        oc exec "$pod" -n node-gather -- nft list table "$family" "$table" 2>/dev/null > "$NODE_PATH/nft-${family}-${table}"
-    done
+    oc exec "$pod" -n node-gather -- nft list ruleset 2>/dev/null > "$NODE_PATH/nftables"
 
     # shellcheck disable=SC2016
     oc exec "$pod" -n node-gather -- /bin/bash -c 'for dev in /host/sys/bus/pci/devices/*; do if [[ -e $dev/sriov_numvfs ]]; then echo "sriov_numvfs on dev ${dev##*/}: $(cat $dev/sriov_numvfs)"; fi; done' >> "$NODE_PATH/sys_sriov_numvfs"

--- a/tests/validate_must_gather_test.go
+++ b/tests/validate_must_gather_test.go
@@ -172,6 +172,7 @@ var _ = Describe("validate the must-gather output", func() {
 				"dmesg",
 				"ip.txt",
 				"lspci",
+				"nftables",
 				"opt-cni-bin",
 				"proc_cmdline",
 				"sys_sriov_numvfs",


### PR DESCRIPTION
Use the command `nft list ruleset` which prints all the nft tables,
instead getting table by table.
    
This way it is also not sensitive to bash parsing,
which split by words instead by lines,
causing the commands to fail collecting the tables.

Note that there will be one file `nftables` with all the tables,
instead one file per table.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2025750

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```

