### PR TITLE
sriov: Update sriov namespace

### DIFF
--- a/collection-scripts/gather_ns
+++ b/collection-scripts/gather_ns
@@ -9,7 +9,7 @@ namespaces=()
 namespaces+=("${INSTALLATION_NAMESPACE}" openshift-operator-lifecycle-manager openshift-marketplace)
 
 # KubeVirt network related namespaces
-namespaces+=(cluster-network-addons openshift-sdn sriov-network-operator)
+namespaces+=(cluster-network-addons openshift-sdn openshift-sriov-network-operator)
 
 # KubeVirt Web UI namespaces
 namespaces+=(kubevirt-web-ui)


### PR DESCRIPTION
Expected openshift namespace of sriov is
openshift-sriov-network-operator.
Update accordingly.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2030686

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```

