### PR TITLE
Fix the validate nodes logs functional test

### DIFF
--- a/tests/validate_must_gather_test.go
+++ b/tests/validate_must_gather_test.go
@@ -172,12 +172,6 @@ var _ = Describe("validate the must-gather output", func() {
 				"dmesg",
 				"ip.txt",
 				"lspci",
-				"nft-ip-filter",
-				"nft-ip-mangle",
-				"nft-ip-nat",
-				"nft-ip6-filter",
-				"nft-ip6-mangle",
-				"nft-ip6-nat",
 				"opt-cni-bin",
 				"proc_cmdline",
 				"sys_sriov_numvfs",
@@ -189,15 +183,23 @@ var _ = Describe("validate the must-gather output", func() {
 			nodesDir := path.Join(outputDir, "nodes")
 			nodes, err := os.ReadDir(nodesDir)
 			Expect(err).ToNot(HaveOccurred())
+			missingExpectedFile := false
 			for _, node := range nodes {
+				if strings.Contains(node.Name(), "master") {
+					continue
+				}
 				Expect(node.IsDir()).To(BeTrue(), node.Name(), " should be a directory")
 				nodeDir := path.Join(nodesDir, node.Name())
 				nodeFiles, err := os.ReadDir(nodeDir)
 				Expect(err).ToNot(HaveOccurred())
 				for _, expectedResource := range expectedResources {
-					Expect(fileInDir(nodeFiles, expectedResource))
+					if !fileInDir(nodeFiles, expectedResource) {
+						logger.Printf("node %s info should include the %s file, but it doesn't", node.Name(), expectedResource)
+						missingExpectedFile = true
+					}
 				}
 			}
+			Expect(missingExpectedFile).To(BeFalse(), "missing expected files")
 
 		})
 


### PR DESCRIPTION
The `"should validate the nodes logs directories" test case in the functional test does not actually test anything, because the `Expect(fileInDir(nodeFiles, expectedResource))` check expects nothing.

This PR changes the test to check all the file and list the missing ones. If any file is missing, the test fails.

Also, the test now does not check the master nodes as daemon sets are not running there.

In addition, this PR does not look for the nft* files in the nodes, because they are missing as result of https://bugzilla.redhat.com/show_bug.cgi?id=2025750. #116 fixes this and will add the related new file to the test.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

