### PR TITLE
Fix bug where the script wrongly processed the VM var

### DIFF
--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -106,7 +106,8 @@ if [[ -n $NS ]]; then
   if [[ -n "${VM}" ]]; then
     mapfile -t VMS < <(echo "${VM}" | tr ',' ' ')
     mapfile -t PODS < <(oc get pod -n "${NS}" --no-headers -o 'custom-columns=name:metadata.name')
-    for vm in "${VMS[@]}"; do
+    # shellcheck disable=SC2068
+    for vm in ${VMS[@]}; do
       POD=$(echo "${PODS[@]}" | tr ' ' '\n' | grep -E "virt-launcher-${vm}-[^-]+$")
       gather_vm_info "${NS}" "${POD}" "${vm}"
     done


### PR DESCRIPTION
The bug ng bz-2059185: this bug is that the script takes the hole VM env var as a VM name, instead of cut it to multiple VMs

This PR fixes the bug.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bz-2059185
```

