### PR TITLE
Fix misleading documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The `VM` environment variable can also be a comma-seperated list of VM names (wi
 oc adm must-gather \
    --image=quay.io/kubevirt/must-gather \
    -- NS=ns1 \
-   VM="testvm1,testvm34,testvm52,testvm74", \
+   VM="testvm1,testvm34,testvm52,testvm74" \
    /usr/bin/gather_vms_details
 ```
 #### Gather VM by Regex Expression
@@ -98,7 +98,7 @@ Here is how to use it in the `gather_vms_details` command, to search VMs by rege
 ```sh
 oc adm must-gather \
    --image=quay.io/kubevirt/must-gather \
-   VM_EXP="^testvm[2-4]-[0-9]*[1,3,5,7,9]$", \
+   VM_EXP="^testvm[2-4]-[0-9]*[1,3,5,7,9]$" \
    /usr/bin/gather_vms_details
 ```
 
@@ -107,7 +107,7 @@ Here is how to use it in the `gather_vms_details` command, to search VMs by rege
 oc adm must-gather \
    --image=quay.io/kubevirt/must-gather \
    -- NS=ns1 \
-   VM_EXP="^testvm[2-4]-[0-9]*[1,3,5,7,9]$", \
+   VM_EXP="^testvm[2-4]-[0-9]*[1,3,5,7,9]$" \
    /usr/bin/gather_vms_details
 ```
 


### PR DESCRIPTION
Remove wrong commas from the examples in README.md, that fails the gathering of VM by regex.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

