### PR TITLE
Fix bug, where the gather_vms_details script fails to collect VM with long names

### DIFF
--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -54,7 +54,7 @@ function gather_vm_by_pod_name() {
   pod=$1
   ocproject=$(echo "$pod" | awk -F_ '{print $1}')
   ocvm=$(echo "$pod" | awk -F_ '{print $2}')
-  vmname=$(echo "${ocvm}" 2>/dev/null | cut -d'-' -f3- | sed "s/-[^-]*$//")
+  vmname=$(echo "$pod" | awk -F_ '{print $3}')
 
   if [[ -n ${VM_EXP} ]]; then
     if [[ ! "${vmname}" =~ ${VM_EXP} ]]; then
@@ -113,7 +113,7 @@ if [[ -n $NS ]]; then
     done
 
   else
-    mapfile -t PODS < <(/usr/bin/oc get pod -n "$NS" -l kubevirt.io=virt-launcher --no-headers -o custom-columns=NAME:.metadata.name)
+    mapfile -t PODS < <(/usr/bin/oc get pod -n "$NS" -l kubevirt.io=virt-launcher --no-headers -o custom-columns="NAME:.metadata.name,VM:.metadata.annotations.kubevirt\.io/domain" | awk '{print $1 "_" $2}')
     echo "${PODS[@]}" | tr ' ' '\n' | xargs -t -P "${PROS}" --max-args=1 -I{} sh -c 'gather_vm_by_pod_name $1' -- "${NS}"_{}
   fi
 
@@ -123,7 +123,7 @@ else
     exit 1
   fi
 
-  mapfile -t PODS < <(oc get pod --all-namespaces -l kubevirt.io=virt-launcher --no-headers | awk '{print $1 "_" $2}')
+  mapfile -t PODS < <(oc get pod --all-namespaces -l kubevirt.io=virt-launcher --no-headers -o custom-columns="NS:.metadata.namespace,NAME:.metadata.name,VM:.metadata.annotations.kubevirt\.io/domain" | awk '{print $1 "_" $2 "_" $3}')
   echo "${PODS[@]}" | tr ' ' '\n' | xargs -P "${PROS}" --max-args=1 -t -I{} sh -c 'gather_vm_by_pod_name $1' -- {}
 
 fi


### PR DESCRIPTION
Fixing BZ-2058925

The bug is where the script is trying to get the vm name from the virt-launcher pod name. The script assumes that the pod name is the vm name with a random addition, separated by a dash. But that is not true for VMs with to long name, and in this case the pod name is not exactly that; e.g. it lack the dash, and the last few characters.

This PR fixes the bug by using different approach to get the VM name from the virt-launcher pod: it reads the `kubevirt.io/domain` annotation in the pod, assuming this is the VM name.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix BZ-2058925
```

