### PR TITLE
Fix the E2E test

### DIFF
--- a/automation/deploy_hco.sh
+++ b/automation/deploy_hco.sh
@@ -52,7 +52,7 @@ spec:
     channel: "${HCO_VERSION}"
 EOF
 
-sleep 60
+sleep 120
 
 # Wait for the deployments to be available
 "${CMD}" wait -n "${NS}" deployment hco-operator --for=condition=Available --timeout="1080s"


### PR DESCRIPTION
The test is failing from time to time, to deploy CNV. This PR check if the deployments exist before trying to check their status.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

