### PR TITLE
Remove from collection namespaces of plain Kubernetes installations

### DIFF
--- a/collection-scripts/gather_ns
+++ b/collection-scripts/gather_ns
@@ -2,17 +2,13 @@
 
 export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
 PROS=${PROS:-5}
-INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}
 
 namespaces=()
 # KubeVirt HCO related namespaces
 namespaces+=("${INSTALLATION_NAMESPACE}" openshift-operator-lifecycle-manager openshift-marketplace)
 
 # KubeVirt network related namespaces
-namespaces+=(cluster-network-addons openshift-sdn openshift-sriov-network-operator)
-
-# KubeVirt Web UI namespaces
-namespaces+=(kubevirt-web-ui)
+namespaces+=(openshift-sdn)
 
 # CDI
 resources+=(cdi)


### PR DESCRIPTION
Must-gather output shows "Error from server (NotFound): namespaces" when it tries to collect information about namespaces only present in plain Kubernetes installations.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove from collection namespaces of plain Kubernetes installations
```

