### PR TITLE
Collect namespaces logs in gather_vms_details

### DIFF
--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -100,6 +100,8 @@ export -f get_vm_rule_tables
 
 "${DIR_NAME}"/vmConvertor
 
+"${DIR_NAME}"/gather_ns
+
 "${DIR_NAME}"/gather_vms_namespaces
 
 if [[ -n $NS ]]; then


### PR DESCRIPTION
Currently, must gather only collects the pod logs from the installation namespace when running the default gather script. When running the VM gather script, these logs were not being collected.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Collect namespaces logs in gather_vms_details
```

