### PR TITLE
Use centos:stream8 in Dockefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN (cd vmConvertor && go build -ldflags="-s -w" .)
 
 FROM quay.io/openshift/origin-must-gather:4.9.0 as builder
 
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream8
 
 ENV INSTALLATION_NAMESPACE kubevirt-hyperconverged
 


### PR DESCRIPTION
Noticed when trying to build a local image for tests, that `docker build` was failing while installing dependencies:

```
Step 8/13 : RUN dnf update -y &&     dnf install iproute tcpdump pciutils util-linux nftables rsync -y &&     dnf clean all
 ---> Running in e9b8f09c8d32
CentOS Linux 8 - AppStream                      135  B/s |  38  B     00:00    
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
The command '/bin/sh -c dnf update -y &&     dnf install iproute tcpdump pciutils util-linux nftables rsync -y &&     dnf clean all' returned a non-zero code: 1
make: *** [Makefile:16: docker-build] Error 1
```

Also noticed that this issue also happened in the [last GitHub build and push image action](https://github.com/kubevirt/must-gather/runs/5476243135?check_suite_focus=true).

Using CentOS Stream 8 fixes this issue.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use centos:stream8 in Dockefile
```

