### PR TITLE
Add script to delete tests workloads

### DIFF
--- a/automation/delete_workloads.sh
+++ b/automation/delete_workloads.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ex
+
+CMD=oc
+
+LABEL_EXP="/^  namespace: ns.*$/a\  labels:\n    vm.kubevirt.io/template: some-template"
+
+for ns in {001..005}; do
+  for vm in {001..020}; do
+    EXP=
+    n=$(echo $vm | sed "s|^0*||")
+    if [[ $(($n%2)) -eq 0 ]]; then
+      EXP="; ${LABEL_EXP}"
+    fi
+    sed -e "s#__NS__#${ns}#g; s|##VM##|${vm}|g${EXP}" automation/vm.yaml | ${CMD} delete -f -
+
+  done
+
+  sed "s#__NS__#${ns}#g" automation/ns.yaml | ${CMD} delete -f -
+done


### PR DESCRIPTION
When testing `must-gather` in pre-existing clusters it would be useful to have a way to cleanup created workloads used for validation.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

