### PR TITLE
Add test commands to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,29 @@
 IMAGE_REGISTRY ?= quay.io
 IMAGE_TAG ?= latest
+GINKGO_JUNIT_REPORT ?= report.xml
 
 # MUST_GATHER_IMAGE needs to be passed explicitly to avoid accidentally pushing to kubevirt/must-gather
-ifndef MUST_GATHER_IMAGE
-$(error MUST_GATHER_IMAGE is not set.)
-endif
+check-image-env:
+	ifndef MUST_GATHER_IMAGE
+	$(error MUST_GATHER_IMAGE is not set.)
+	endif
 
-build: docker-build docker-push
+build: check-image-env docker-build docker-push
 
 # check
 check:
 	shellcheck -e SC2016 collection-scripts/*
 
-docker-build:
+docker-build: check-image-env
 	docker build -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG} .
 
-docker-push:
+docker-push: check-image-env
 	docker push ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG}
+
+test-build:
+	(cd tests; go test -c -o must-gather.test .)
+
+test: test-build
+	tests/must-gather.test --ginkgo.label-filter=level:product --ginkgo.junit-report=${GINKGO_JUNIT_REPORT} --ginkgo.v
 
 .PHONY: build docker-build docker-push


### PR DESCRIPTION
When running tests in an automated way it would be nice to abstract how tests are built and executed and just be able to run `make test`. Also the recent #141 changes how these steps are done when comparing, for example with `release-4.10`, which would require different test script configurations for each version when not just using something like `make test`.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

