### PR TITLE
gather_vms_details: adapt to rootless virt-launcher

### DIFF
--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -4,6 +4,8 @@ export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
 export PROS="${PROS:-5}"
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 INSTALLATION_NAMESPACE="${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}"
+export QEMULOGPATH_1="/var/log/libvirt/qemu/"
+export QEMULOGPATH_2="/var/run/libvirt/qemu/log/"
 
 function gather_vm_info() {
   ocproject=$1
@@ -21,7 +23,7 @@ function gather_vm_info() {
 
   # VM : QEMU logs
   # libvirt logs are already relayed to virt-launcher, and we capture the virt-launcher pod logs elsewhere. We are want the QEMU log here.
-  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- cat "/var/log/libvirt/qemu/${ocproject}_${vmname}.log" > "${vm_collection_path}/${ocvm}.qemu.log"
+  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- tar --ignore-failed-read -cf - "${QEMULOGPATH_1}" "${QEMULOGPATH_2}" | tar -C "${vm_collection_path}" --transform 's/.*\///g' -xvf -
 
   # VM : IP
   /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- ip a 2>/dev/null > "${vm_collection_path}/${ocvm}.ip.txt"
@@ -75,7 +77,7 @@ function get_vm_rule_tables() {
 
   handler=$(/usr/bin/oc get pods -A -l kubevirt.io=virt-handler -o=custom-columns=NAME:.metadata.name --field-selector spec.nodeName="${vmnode}" --no-headers)
 
-  pid=$(/usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "pgrep -f \"uid ${vmuid}.*no-fork\"")
+  pid=$(/usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "pgrep -f 'virt-launcher .*${vmuid}'")
 
   if /usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "nft -v" > /dev/null 2>&1; then
     /usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "nsenter -t ${pid} -n -- nft list ruleset" 2>/dev/null


### PR DESCRIPTION
gather_vms_details: adapt to rootless virt-launcher
1. The root virt-launcher is saving qemu logs under
/var/log/libvirt/qemu/
while the rootless one under
/var/run/libvirt/qemu/log/

logs for long running VMs are periodically rotated
as .0, .1 and so on.

Try to always collect whatever is readable.

2. Fix the mechanism used to identify the PID
of virt-launcher process to work also
with rootless virt-launcher

3. Fix functional tests to ensure we always
get a not zero bytes long logs from VMs.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2076379

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
gather_vms_details: adapt to rootless virt-launcher
```

