### PR TITLE
[release-4.9] Bug 2086898: Remove from collection namespaces of plain Kubernetes installations

### DIFF
--- a/collection-scripts/gather_ns
+++ b/collection-scripts/gather_ns
@@ -9,10 +9,7 @@ namespaces=()
 namespaces+=("${INSTALLATION_NAMESPACE}" openshift-operator-lifecycle-manager openshift-marketplace)
 
 # KubeVirt network related namespaces
-namespaces+=(cluster-network-addons openshift-sdn sriov-network-operator)
-
-# KubeVirt Web UI namespaces
-namespaces+=(kubevirt-web-ui)
+namespaces+=(openshift-sdn)
 
 # CDI
 resources+=(cdi)


### PR DESCRIPTION
Manual cherry-pick of #130 

Must-gather output shows "Error from server (NotFound): namespaces" when it tries to collect information about namespaces only present in plain Kubernetes installations.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove from collection namespaces of plain Kubernetes installations
```

