### PR TITLE
Add instancetype support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ Or
 oc adm must-gather --image=quay.io/kubevirt/must-gather -- PROS=3 /usr/bin/gather --images
 ```
 
+### Targeted gathering - Instancetypes and preferences
+
+VirtualMachineInstancetypes and VirtualMachinePreferences are not currently collected by default but can be
+by running the following command:
+
+```sh
+oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather --instancetypes
+```
+
 ## Development
 You can build the image locally using the Dockerfile included.
 

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -96,6 +96,10 @@ function parse_flags {
         no_flags="false"
         requested_scripts[$1]="true"
         ;;
+      --instancetypes)
+        no_flags="false"
+        requested_scripts[$1]="true"
+        ;;
       --)
         shift
         break
@@ -141,6 +145,7 @@ Usage: oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gathe
   --images
   --vms_details
   --vms_namespaces
+  --instancetypes
 "
 }
 

--- a/collection-scripts/gather_instancetypes
+++ b/collection-scripts/gather_instancetypes
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+PROS=${PROS:-5}
+
+resources=(virtualmachineinstancetype virtulmachineclusterinstancetype virtualmachinepreference virtualmachineclusterpreference)
+
+echo "${resources[@]}" | tr ' ' '\n' | xargs -t -I{} -P "${PROS}" --max-args=1 sh -c 'echo "inspecting $1" && oc adm inspect --dest-dir ${BASE_COLLECTION_PATH} --all-namespaces $1' -- {}
+


### PR DESCRIPTION
This change introduces basic collection support for the following CRDs:

- VirtualMachineInstancetype
- VirtualMachineClusterInstancetype
- VirtualMachinePreference
- VirtualMachineClusterPreference

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The instancetype API CRDs `VirtualMachineInstancetype`, `VirtualMachineClusterInstancetype`, `VirtualMachinePreference and `VirtualMachineClusterPreference` are now collected.
```

