### PR TITLE
Simplify must-gather usage

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -11,15 +11,21 @@ jobs:
     name: Pull Request Sanity
     runs-on: ubuntu-latest
     steps:
-    - name: ShellCheck
+    - name: Checkout
       uses: actions/checkout@v2
       with:
         ref: ${{ github.ref }}
     - uses: actions/setup-go@v2
       with:
         go-version: '1.19' # The Go version to download (if necessary) and use.
-    - name: Check scripts
-      run: shellcheck -e SC2016 collection-scripts/*
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      env:
+        SHELLCHECK_OPTS: -a -e SC2016 --source-path=./collection-scripts
+      with:
+         check_together: 'yes'
+         version: v0.8.0
+         scandir: './collection-scripts/'
     - name: check vmConvertor
       run: |-
         cd cmd/vmConvertor

--- a/README.md
+++ b/README.md
@@ -24,26 +24,18 @@ run `oc adm must-gather` (without passing a custom image). Run `oc adm must-gath
 ### Flags
 
 `must-gather` provides a series of options to select which information to
-collect from the cluster. If no flag is provided the tool will collect a default
-set of information, marked with "`(default)`" in the help menu, as shown in the
-next section. You can also use the `--default` or any other listed flags to fine
-tune the information to collect.
+collect from the cluster. The tool will always collect all control-plane logs and information.
+Optional collectors can be enabled with CLI options.
 
-To run the default collectors:
+
+To run only the default collectors:
 ```sh
 oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather
-# or
-oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather --default
-```
-
-To collect Virtual Machines and VMs details:
-```sh
-oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather --virtualmachines --vms_details
 ```
 
 To collect all default information and VMs details:
 ```sh
-oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather --default --vms_details
+oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather --vms_details
 ```
 
 ### Help Menu
@@ -61,26 +53,28 @@ Usage: oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gathe
 
   Available options:
 
-  > To collect all default information (this is automatically selected if no
-  > parameter is set) use
-  --default
+  > To see this help menu and exit use
+  --help
 
-  > You can also select which information must-gather will collect by using one
-  > or more of the following parameters
-  --apiservices     (default)
-  --cdi             (default)
-  --crds            (default)
-  --crs             (default)
-  --hco             (default)
-  --nodes           (default)
-  --ns              (default)
-  --resources       (default)
-  --ssp             (default)
-  --virtualmachines (default)
-  --webhooks        (default)
+  > The tool will always collect all control-plane logs and information.
+  > This will include:
+  > - apiservices
+  > - cdi
+  > - crds
+  > - crs
+  > - hco
+  > - nodes
+  > - ns
+  > - resources
+  > - ssp
+  > - virtualmachines
+  > - webhooks
+
+  > You can also choose to enable optional collectors combining one
+  > or more of the following parameters:
   --images
+  --instancetypes
   --vms_details
-  --vms_namespaces
 ```
 
 ### Parallelism
@@ -98,7 +92,7 @@ oc adm must-gather \
 
 ### Targeted gathering - VM information
 
-To collect the VM information, and all the namespaces that contains VMs call directly the `gather --vms_details` command:
+To collect the default control plane information and VM detailed information you can append `--vms_details` command line flag:
 ```sh
 oc adm must-gather \
    --image=quay.io/kubevirt/must-gather \
@@ -106,8 +100,7 @@ oc adm must-gather \
 ```
 
 #### VMs in a Namespace
-The `gather --vms_details` command supports targeted gathering. By specifying a namespace, the command will only 
-collect the VMs in this namespace. For example, collecting all the VM information in namespace "vm1":
+The `--vms_details` flag supports targeted gathering. By specifying a namespace, the command will only collect detailed VM logs for the VMs in this namespace (control plane logs are always collected). For example, collecting all the VM information in namespace "vm1":
 ```sh
 oc adm must-gather \
    --image=quay.io/kubevirt/must-gather \
@@ -116,8 +109,8 @@ oc adm must-gather \
 ```
 
 #### Specific VM
-By specifying the VM name in addition to the namespace, the `gather --vms_details` command will only collect the specific
-VM information. For example, collecting the information of a specific VM called "testvm" in namespace "vm1":
+By specifying the VM name in addition to the namespace, the `--vms_details` flag will only collect the specific
+VM information (control plane logs are always collected). For example, collecting the information of a specific VM called "testvm" in namespace "vm1":
 ```sh
 oc adm must-gather \
    --image=quay.io/kubevirt/must-gather \
@@ -138,7 +131,7 @@ oc adm must-gather \
    /usr/bin/gather --vms_details
 ```
 #### Gather VM by Regex Expression
-The `gather --vms_details` command also support gathering VM with regex expression.
+The `--vms_details` flag also support gathering VM with regex expression.
 
 For example, suppose we have the following VMs in the cluster:
 ```
@@ -156,7 +149,7 @@ testvm5-6 testvm5-7 testvm5-8 testvm5-9 testvm5-10
 
 If we want to read only VMs that starts with testvm2, testvm3 or testvm4, and that their postfix number is odd, we can use this regex expression to for that: `^testvm[2-4]-[0-9]*[1,3,5,7,9]$`.
 
-Here is how to use it in the `gather --vms_details` command, to search VMs by regex:
+Here is how to use it in the `--vms_details` flag, to search VMs by regex:
 ```sh
 oc adm must-gather \
    --image=quay.io/kubevirt/must-gather \
@@ -164,7 +157,7 @@ oc adm must-gather \
    /usr/bin/gather --vms_details
 ```
 
-Here is how to use it in the `gather --vms_details` command, to search VMs by regex in the `ns1` namespace:
+Here is how to use it in the `--vms_details` flag, to search VMs by regex in the `ns1` namespace:
 ```sh
 oc adm must-gather \
    --image=quay.io/kubevirt/must-gather \
@@ -178,12 +171,12 @@ oc adm must-gather \
 
 ### Targeted gathering - Images information
 
-It is possible to collect image, image-stream and image-stream-tags information using the `gather --images` command:
+It is possible to collect image, image-stream and image-stream-tags information using the `--images` flag:
 ```sh
 oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather --images
 ```
 
-The `gather --vms_details` and the `gather --images` commands support parallelism as well. To change the default number of processes of 5, add the
+The `--vms_details` and the `--images` flags support parallelism as well. To change the default number of processes of 5, add the
 `PROS` environment variable. This is only works when not using the `NS` environment variable:
 ```sh
 oc adm must-gather --image=quay.io/kubevirt/must-gather -- PROS=7 /usr/bin/gather --vms_details

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+export PROS=${PROS:-5}
+export INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}
+
+function check_command {
+    if [[ -z "$USR_BIN_GATHER" ]]; then
+        echo "This script should not be directly executed." 1>&2
+        echo "Please check \"${DIR_NAME}/gather --help\" for execution options." 1>&2
+        exit 1
+    fi
+}
+

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -5,21 +5,20 @@ export PROS=${PROS:-5}
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 function main() {
-  declare no_flags="true"
-  declare -A requested_scripts=()
-  declare default_params=(
-    "--apiservices"
-    "--cdi"
-    "--crds"
-    "--crs"
-    "--hco"
-    "--nodes"
-    "--ns"
-    "--resources"
-    "--ssp"
-    "--virtualmachines"
-    "--webhooks"
+  declare mandatory_scripts=(
+    "apiservices"
+    "cdi"
+    "crds"
+    "crs"
+    "hco"
+    "nodes"
+    "ns"
+    "resources"
+    "ssp"
+    "virtualmachines"
+    "webhooks"
   )
+  declare requested_scripts=("${mandatory_scripts[@]}")
 
   parse_flags "$@"
   run_scripts
@@ -36,69 +35,15 @@ function parse_flags {
         help
         exit 0
         ;;
-      --default)
-        no_flags="false"
-        set_default_as_requested
-        ;;
-      --apiservices)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --cdi)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --crds)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --crs)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --hco)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
       --images)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --nodes)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --ns)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --resources)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --ssp)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --virtualmachines)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --vms_details)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --vms_namespaces)
-        no_flags="false"
-        requested_scripts[$1]="true"
-        ;;
-      --webhooks)
-        no_flags="false"
-        requested_scripts[$1]="true"
+        requested_scripts+=("images")
         ;;
       --instancetypes)
-        no_flags="false"
-        requested_scripts[$1]="true"
+        requested_scripts+=("instancetypes")
+        ;;
+      --vms_details)
+        requested_scripts+=("vms_details")
+        requested_scripts+=("vms_namespaces")
         ;;
       --)
         shift
@@ -125,52 +70,33 @@ Usage: oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gathe
   > To see this help menu and exit use
   --help
 
-  > To collect all default information (this is automatically selected if no
-  > parameter is set) use
-  --default
+  > The tool will always collect all control-plane logs and information.
+  > This will include:"
+    for collector in "${mandatory_scripts[@]}" ; do
+    echo "  > - $collector"
+    done
+    echo "\
 
-  > You can also select which information must-gather will collect by using one
-  > or more of the following parameters
-  --apiservices     (default)
-  --cdi             (default)
-  --crds            (default)
-  --crs             (default)
-  --hco             (default)
-  --nodes           (default)
-  --ns              (default)
-  --resources       (default)
-  --ssp             (default)
-  --virtualmachines (default)
-  --webhooks        (default)
+  > You can also choose to enable optional collectors combining one
+  > or more of the following parameters:
   --images
-  --vms_details
-  --vms_namespaces
   --instancetypes
+  --vms_details
 "
 }
 
-function set_default_as_requested {
-  for default_param in "${default_params[@]}";
-  do
-    requested_scripts[$default_param]="true"
-  done
-}
-
 function run_scripts {
-  if [ "$no_flags" == "true" ]; then
-    set_default_as_requested
-  fi
-
-  for script in "${!requested_scripts[@]}";
+  for script in "${requested_scripts[@]}";
   do
-    echo "running gather_${script:2}"
-    eval "${DIR_NAME}/gather_${script:2}"
+    script_name="gather_${script}"
+    echo "running ${script_name}"
+    eval USR_BIN_GATHER=1 "${DIR_NAME}/${script_name}"
   done
 }
 
 function run_logs {
   echo "running logs"
-  "${DIR_NAME}"/logs.sh
+  USR_BIN_GATHER=1 "${DIR_NAME}"/logs.sh
 }
 
 main "$@"; exit

--- a/collection-scripts/gather_apiservices
+++ b/collection-scripts/gather_apiservices
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
-BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 # Resource list
 resources=$(/usr/bin/oc get apiservices | grep kubevirt.io | awk '{ print $1 }')

--- a/collection-scripts/gather_cdi
+++ b/collection-scripts/gather_cdi
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
-BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 function gather_cdi_pod() {
   line=$1

--- a/collection-scripts/gather_crds
+++ b/collection-scripts/gather_crds
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
-export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 # Resource list
 CRDS=$(/usr/bin/oc get crd | grep kubevirt.io | awk '{print $1}')

--- a/collection-scripts/gather_crs
+++ b/collection-scripts/gather_crs
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
-export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-export PROS=${PROS:-5}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 function get_cr() {
   ocobject=$(echo "$2" | awk -F_ '{print $1}')

--- a/collection-scripts/gather_hco
+++ b/collection-scripts/gather_hco
@@ -1,11 +1,12 @@
 #!/bin/bash -x
 
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
+
 IFS=$'\n'
 
-BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-
 NAMESPACE_PATH=${BASE_COLLECTION_PATH}/namespaces
-INSTALLATION_NAMESPACE="${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}"
 
 mkdir -p "${NAMESPACE_PATH}/${INSTALLATION_NAMESPACE}"
 

--- a/collection-scripts/gather_images
+++ b/collection-scripts/gather_images
@@ -1,10 +1,10 @@
 #!/bin/bash -x
 
-# Workaround for: https://github.com/openshift/must-gather/issues/122
-
-BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
+
+# Workaround for: https://github.com/openshift/must-gather/issues/122
 
 IMAGES_PATH=${BASE_COLLECTION_PATH}/cluster-scoped-resources/images
 export NAMESPACE_PATH=${BASE_COLLECTION_PATH}/namespaces

--- a/collection-scripts/gather_instancetypes
+++ b/collection-scripts/gather_instancetypes
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
-export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 resources=(virtualmachineinstancetype virtulmachineclusterinstancetype virtualmachinepreference virtualmachineclusterpreference)
 

--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -1,7 +1,9 @@
 #!/bin/bash -x
 
-BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
+
 MANIFEST_PATH=${MANIFEST_PATH:-"/etc"}
 
 check_node_gather_pods_ready() {

--- a/collection-scripts/gather_ns
+++ b/collection-scripts/gather_ns
@@ -1,8 +1,8 @@
 #!/bin/bash -x
 
-export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
-INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 namespaces=()
 # KubeVirt HCO related namespaces

--- a/collection-scripts/gather_resources
+++ b/collection-scripts/gather_resources
@@ -1,8 +1,8 @@
 #!/bin/bash -x
 
-export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-export PROS=${PROS:-5}
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 # Resource list
 resources=()

--- a/collection-scripts/gather_ssp
+++ b/collection-scripts/gather_ssp
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
-BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 # we expect the KubeVirt templates to be deployed only in the `opneshift` namespace. But if this turns out not to be true, we need to know.
 namespaces=$(/usr/bin/oc get templates --all-namespaces -l 'template.kubevirt.io/type=base' -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' | uniq)

--- a/collection-scripts/gather_virtualmachines
+++ b/collection-scripts/gather_virtualmachines
@@ -1,6 +1,8 @@
 #!/bin/bash -x
 
-export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 vmConvertor
 

--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -1,9 +1,9 @@
 #!/bin/bash -x
 
-export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-export PROS="${PROS:-5}"
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-INSTALLATION_NAMESPACE="${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}"
+source "${DIR_NAME}/common.sh"
+check_command
+
 export QEMULOGPATH_1="/var/log/libvirt/qemu/"
 export QEMULOGPATH_2="/var/run/libvirt/qemu/log/"
 export QEMULOGPATH_3="/var/run/kubevirt-private/libvirt/qemu/log/"

--- a/collection-scripts/gather_vms_namespaces
+++ b/collection-scripts/gather_vms_namespaces
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
-export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 if [[ -n $NS ]]; then
   namespaces="${NS}"

--- a/collection-scripts/gather_webhooks
+++ b/collection-scripts/gather_webhooks
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
-BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
-PROS=${PROS:-5}
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
 
 function gather_validating_wh() {
   webhooks_collection_path=${BASE_COLLECTION_PATH}/webhooks/validating/${1}

--- a/collection-scripts/logs.sh
+++ b/collection-scripts/logs.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -x
 
-export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
+
 NAMESPACE_FILE=/var/run/secrets/kubernetes.io/serviceaccount/namespace
 
 # if running in a pod


### PR DESCRIPTION
We occasionally still get must-gather archives
which contains only a subset of the desired information so I think its usage is still not so intuitive.

Let's try to simplify even more:

1. single entry point script: all the collectors scripts will generate a clear error if directly executed: 
```
This script should not be directly executed.
Please check "/usr/bin/gather --help" for execution options.
```

2. always execute the mandatory collectors without the need to remember to explicitly add --default option

3. reduce the number of CLI options keeping there only optional collectors

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Simplify must-gather usage
```

