### PR TITLE
Log golden images namespace as well for debugging

### DIFF
--- a/collection-scripts/gather_ns
+++ b/collection-scripts/gather_ns
@@ -11,6 +11,9 @@ namespaces+=("${INSTALLATION_NAMESPACE}" openshift-operator-lifecycle-manager op
 # KubeVirt network related namespaces
 namespaces+=(openshift-sdn)
 
+# Golden images namesapce
+namespaces+=(openshift-virtualization-os-images)
+
 # CDI
 resources+=(cdi)
 


### PR DESCRIPTION
This is helpful in debugging clones from golden images, which is definitely a common flow

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

**Maintainer note**:
Should we differentiate upstream/downstream and also log the community version of `openshift-virtualization-os-images`?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add logging of golden image namespace
```

