### PR TITLE
Use bridge command instead of brctl

### DIFF
--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -32,9 +32,9 @@ function gather_vm_info() {
   # VM : Bridge
   {
     echo "###################################"
-    echo "brctl show:"
+    echo "bridge link show:"
     echo "###################################"
-    /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- brctl show 2>/dev/null
+    /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- bridge link show 2>/dev/null
 
     echo "###################################"
     echo "bridge fdb show:"


### PR DESCRIPTION
bridge-utils was deprecated in rhel 7 and was removed in rhel 8. Use bridge link show instead of brctl show.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=2216449

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Substitute brctl show with the bridge Command
```

