### PR TITLE
Don't Collect VM data from completed virt-launcher pods

### DIFF
--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -132,7 +132,7 @@ else
     exit 1
   fi
 
-  mapfile -t PODS < <(oc get pod --all-namespaces -l kubevirt.io=virt-launcher --no-headers -o custom-columns="NS:.metadata.namespace,NAME:.metadata.name,VM:.metadata.annotations.kubevirt\.io/domain" | awk '{print $1 "_" $2 "_" $3}')
+  mapfile -t PODS < <(oc get pod --all-namespaces -l kubevirt.io=virt-launcher --field-selector=status.phase!=Succeeded --no-headers -o custom-columns="NS:.metadata.namespace,NAME:.metadata.name,VM:.metadata.annotations.kubevirt\.io/domain" | awk '{print $1 "_" $2 "_" $3}')
   echo "${PODS[@]}" | tr ' ' '\n' | xargs -P "${PROS}" --max-args=1 -t -I{} sh -c 'gather_vm_by_pod_name $1' -- {}
 
 fi


### PR DESCRIPTION
If the VMs are live migrated, there will be source virt-launcher pods with status "completed". So oc exec will fail on these pods with error "cannot exec into a container in a completed pod". This results in many empty files under `vms/<vm-name> ` if the VM was migrated multiple times. So run gather_vm_info only for "running" pods.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=2216447

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Collect VM data only from running virt-launcher pods
```

