### PR TITLE
Collect openshift-ovn-kubernetes on OVN OCP clusters

### DIFF
--- a/collection-scripts/gather_ns
+++ b/collection-scripts/gather_ns
@@ -9,7 +9,12 @@ namespaces=()
 namespaces+=("${INSTALLATION_NAMESPACE}" openshift-operator-lifecycle-manager openshift-marketplace)
 
 # KubeVirt network related namespaces
-namespaces+=(openshift-sdn)
+NETWORK_TYPE=$(oc get network.config.openshift.io -o=jsonpath='{.items[0].spec.networkType}' | tr '[:upper:]' '[:lower:]')
+if [[ "${NETWORK_TYPE}" == "ovnkubernetes" ]]; then
+  namespaces+=(openshift-ovn-kubernetes)
+elif [[ "${NETWORK_TYPE}" == "openshiftsdn" ]]; then
+  namespaces+=(openshift-sdn)
+fi
 
 # Golden images namesapce
 namespaces+=(openshift-virtualization-os-images)


### PR DESCRIPTION
As of now, it's trying to get the inspect only from ns/openshift-sdn. Find the cluster network type and collect either openshift-sdn or openshift-ovn-kubernetes based on the network type.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=2214503

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Collect openshift-ovn-kubernetes on OVN OCP clusters
```

