### PR TITLE
Use fewer oc exec commands to collect bridge and firewall information

### DIFF
--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -30,22 +30,22 @@ function gather_vm_info() {
   /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- ip a 2>/dev/null > "${vm_collection_path}/${ocvm}.ip.txt"
 
   # VM : Bridge
-  {
-    echo "###################################"
-    echo "bridge link show:"
-    echo "###################################"
-    /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- bridge link show 2>/dev/null
-
-    echo "###################################"
-    echo "bridge fdb show:"
-    echo "###################################"
-    /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- bridge fdb show 2>/dev/null
-
-    echo "###################################"
-    echo "bridge vlan show:"
-    echo "###################################"
-    /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- bridge vlan show 2>/dev/null
-  } > "${vm_collection_path}/${ocvm}.bridge.txt"
+  bridge_commands=$(cat <<EOF
+echo "###################################"
+echo "bridge link show:"
+echo "###################################"
+bridge link show 2>/dev/null
+echo "###################################"
+echo "bridge fdb show:"
+echo "###################################"
+bridge fdb show 2>/dev/null
+echo "###################################"
+echo "bridge vlan show:"
+echo "###################################"
+bridge vlan show 2>/dev/null
+EOF
+)
+  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- /bin/bash -c "$bridge_commands"  > "${vm_collection_path}/${ocvm}.bridge.txt"
 
   # VM : nftables / iptables
   {
@@ -79,20 +79,23 @@ function get_vm_rule_tables() {
   handler=$(/usr/bin/oc get pods -A -l kubevirt.io=virt-handler -o=custom-columns=NAME:.metadata.name --field-selector spec.nodeName="${vmnode}" --no-headers)
 
   pid=$(/usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "pgrep -f '^/usr/bin/virt-launcher .*${vmuid}'")
+  rule_commands=$(cat <<EOF
+if nft -v > /dev/null 2>&1; then
+  nsenter -t ${pid} -n -- nft list ruleset 2>/dev/null
+else
+  echo "###################################"
+  echo "Filter table:"
+  echo "###################################"
+  nsenter -t ${pid} -n -- iptables -t filter -L 2>/dev/null
 
-  if /usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "nft -v" > /dev/null 2>&1; then
-    /usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "nsenter -t ${pid} -n -- nft list ruleset" 2>/dev/null
-  else
-    echo "###################################"
-    echo "Filter table:"
-    echo "###################################"
-    /usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "nsenter -t ${pid} -n -- iptables -t filter -L" 2>/dev/null
-
-    echo -e "\n\n###################################"
-    echo "NAT table:"
-    echo "###################################"
-    /usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "nsenter -t ${pid} -n -- iptables -t nat -L" 2>/dev/null
-  fi
+  echo -e "\n\n###################################"
+  echo "NAT table:"
+  echo "###################################"
+  nsenter -t ${pid} -n -- iptables -t nat -L 2>/dev/null
+fi
+EOF
+)
+  /usr/bin/oc exec -n "${INSTALLATION_NAMESPACE}" "${handler}" -- /bin/bash -c "$rule_commands" 
 }
 
 export -f gather_vm_by_pod_name


### PR DESCRIPTION
It is faster if we use a single oc exec command and runs the commands in a single shell instead of initiating multiple requests to api.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use fewer oc exec commands to collect bridge and firewall information
```

