### PR TITLE
Add details about VMs using virsh

### DIFF
--- a/collection-scripts/gather_vms_details
+++ b/collection-scripts/gather_vms_details
@@ -19,8 +19,28 @@ function gather_vm_info() {
   /usr/bin/oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" -n "${ocproject}" pod "$ocvm"
   /usr/bin/oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" -n "${ocproject}" virtualmachineinstances "${vmname}"
 
+  # VM : capabilities
+  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- virsh -r capabilities  > "${vm_collection_path}/${ocvm}.capabilities.xml"
+
+  # VM : domcapabilities
+  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- virsh  domcapabilities  > "${vm_collection_path}/${ocvm}.domcapabilities.xml"
+
+  # VM : list
+  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- virsh -r list --all  > "${vm_collection_path}/${ocvm}.list.txt"
+
   # VM : dumpxml
-  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- virsh dumpxml "${ocproject}_${vmname}" > "${vm_collection_path}/${ocvm}.dumpxml.xml"
+  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- virsh -r dumpxml "${ocproject}_${vmname}" > "${vm_collection_path}/${ocvm}.dumpxml.xml"
+
+  # VM : domblklist
+  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- virsh -r domblklist "${ocproject}_${vmname}" > "${vm_collection_path}/${ocvm}.domblklist.txt"
+
+  # VM : domjobinfo
+  /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- virsh -r domjobinfo "${ocproject}_${vmname}" > "${vm_collection_path}/${ocvm}.domjobinfo.txt"
+
+  # VM : blockjob
+  awk 'NR > 2 {print $2}' "${vm_collection_path}/${ocvm}.domblklist.txt" | while IFS= read -r disk; do
+    /usr/bin/oc exec "${ocvm}" -n "${ocproject}" -c compute -- virsh -r blockjob "${ocproject}_${vmname}" "${disk}" >> "${vm_collection_path}/${ocvm}.blockjob.txt"
+  done
 
   # VM : QEMU logs
   # libvirt logs are already relayed to virt-launcher, and we capture the virt-launcher pod logs elsewhere. We are want the QEMU log here.

--- a/tests/validate_must_gather_test.go
+++ b/tests/validate_must_gather_test.go
@@ -240,10 +240,16 @@ var _ = Describe("validate the must-gather output", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			fileExistsNotEmpty := map[string]bool{
-				"bridge.txt":     false,
-				"dumpxml.xml":    false,
-				"ruletables.txt": false,
-				"ip.txt":         false,
+				"bridge.txt":          false,
+				"dumpxml.xml":         false,
+				"ruletables.txt":      false,
+				"ip.txt":              false,
+				"capabilities.xml":    false,
+				"domcapabilities.xml": false,
+				"list.txt":            false,
+				"domblklist.txt":      false,
+				"domjobinfo.txt":      false,
+				"blockjob.txt":        false,
 			}
 
 			dotLoc := 0


### PR DESCRIPTION
Extend kubevirt must-gather collection to collect more info with virsh command.

Which issue(s) this PR fixes:
https://issues.redhat.com/browse/CNV-26740

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added capabilities.xml
Added domcapabilities.xml
Added list.txt 
Added domblklist.txt 
Added domjobinfo.txt
Added blockjob.txt
```

