### PR TITLE
Fix `virtulmachineclusterinstancetype` typo

### DIFF
--- a/collection-scripts/gather_instancetypes
+++ b/collection-scripts/gather_instancetypes
@@ -4,7 +4,7 @@ DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${DIR_NAME}/common.sh"
 check_command
 
-resources=(virtualmachineinstancetype virtulmachineclusterinstancetype virtualmachinepreference virtualmachineclusterpreference)
+resources=(virtualmachineinstancetype virtualmachineclusterinstancetype virtualmachinepreference virtualmachineclusterpreference)
 
 echo "${resources[@]}" | tr ' ' '\n' | xargs -t -I{} -P "${PROS}" --max-args=1 sh -c 'echo "inspecting $1" && oc adm inspect --dest-dir ${BASE_COLLECTION_PATH} --all-namespaces $1' -- {}
 


### PR DESCRIPTION
Fix `virtulmachineclusterinstancetype` -> `virtualmachineclusterinstancetype` in `gather_instancetypes` script.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix typo in `virtulmachineclusterinstancetype`
```

