### PR TITLE
Handle the introduction of instancetypes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/kubevirt/must-gather/cmd
 COPY cmd .
 RUN (cd vmConvertor && go build -ldflags="-s -w" .)
 
-FROM quay.io/openshift/origin-must-gather:4.12.0 as builder
+FROM quay.io/openshift/origin-must-gather:4.13.0 as builder
 
 FROM quay.io/centos/centos:stream8
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Usage: oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gathe
   > You can also choose to enable optional collectors combining one
   > or more of the following parameters:
   --images
-  --instancetypes
   --vms_details
 ```
 
@@ -184,15 +183,6 @@ oc adm must-gather --image=quay.io/kubevirt/must-gather -- PROS=7 /usr/bin/gathe
 Or
 ```sh
 oc adm must-gather --image=quay.io/kubevirt/must-gather -- PROS=3 /usr/bin/gather --images
-```
-
-### Targeted gathering - Instancetypes and preferences
-
-VirtualMachineInstancetypes and VirtualMachinePreferences are not currently collected by default but can be
-by running the following command:
-
-```sh
-oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather --instancetypes
 ```
 
 ## Development

--- a/automation/deploy_hco.sh
+++ b/automation/deploy_hco.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-HCO_VERSION=1.8.0
+HCO_VERSION=1.9.0
 UNSTABLE="-unstable"
 MINOR_VER="${HCO_VERSION%.*}"
 CMD=oc

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -17,6 +17,7 @@ function main() {
     "ssp"
     "virtualmachines"
     "webhooks"
+    "instancetypes"
   )
   declare requested_scripts=("${mandatory_scripts[@]}")
 
@@ -37,9 +38,6 @@ function parse_flags {
         ;;
       --images)
         requested_scripts+=("images")
-        ;;
-      --instancetypes)
-        requested_scripts+=("instancetypes")
         ;;
       --vms_details)
         requested_scripts+=("vms_details")
@@ -80,7 +78,6 @@ Usage: oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gathe
   > You can also choose to enable optional collectors combining one
   > or more of the following parameters:
   --images
-  --instancetypes
   --vms_details
 "
 }

--- a/collection-scripts/gather_instancetypes
+++ b/collection-scripts/gather_instancetypes
@@ -4,7 +4,19 @@ DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${DIR_NAME}/common.sh"
 check_command
 
-resources=(virtualmachineinstancetype virtulmachineclusterinstancetype virtualmachinepreference virtualmachineclusterpreference)
+resources=(virtualmachineinstancetype virtualmachineclusterinstancetype virtualmachinepreference virtualmachineclusterpreference)
 
 echo "${resources[@]}" | tr ' ' '\n' | xargs -t -I{} -P "${PROS}" --max-args=1 sh -c 'echo "inspecting $1" && oc adm inspect --dest-dir ${BASE_COLLECTION_PATH} --all-namespaces $1' -- {}
+
+function gather_controller_revision() {
+  oc_project=$(echo "$1" | awk -F_ '{print $1}')
+  revision_name=$(echo "$1" | awk -F_ '{print $2}')
+  echo "inspecting ${revision_name} controller revision"
+
+  /usr/bin/oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" -n "${oc_project}" controllerrevision "${revision_name}"
+}
+
+export -f gather_controller_revision
+controller_revisions=$(oc get controllerrevision --all-namespaces | grep virtualmachine | awk '{print $1 "_" $2}')
+echo "${controller_revisions[@]}" | tr ' ' '\n' | xargs -P "${PROS}" --max-args=1 -t -I{} sh -c 'gather_controller_revision $1' -- {}
 

--- a/tests/validate_must_gather_test.go
+++ b/tests/validate_must_gather_test.go
@@ -105,6 +105,8 @@ var _ = Describe("validate the must-gather output", func() {
 				"cdiconfigs.cdi.kubevirt.io": false,
 				"cdis.cdi.kubevirt.io":       false,
 				"networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io": false,
+				"virtualmachineclusterinstancetypes.instancetype.kubevirt.io":    false,
+				"virtualmachineclusterpreferences.instancetype.kubevirt.io":      false,
 			}
 
 			for expectedResource := range expectedResources {
@@ -120,7 +122,12 @@ var _ = Describe("validate the must-gather output", func() {
 				crDir := path.Join(crsDir, cr.Name())
 				crFiles, err := os.ReadDir(crDir)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(crFiles).Should(HaveLen(1))
+
+				if strings.Contains(cr.Name(), "instancetype") {
+					Expect(crFiles).ShouldNot(BeEmpty())
+				} else {
+					Expect(crFiles).Should(HaveLen(1))
+				}
 
 				if crFiles[0].IsDir() {
 					continue


### PR DESCRIPTION
This PR does the following:
- Enable the collection of `instancetypes` by default.
- Collect `controllerrevisions` that are associated with VMs. `controllerrevisions` are useful as they contain a point in time of the associated instance type or preference that may have been mutated or deleted. For example, when an instance type is patched, an associated VM won't get updated, unless requested explicitly, as it points to the older `controllerrevision`. For more information, PTAL at https://kubevirt.io/user-guide/virtual_machines/instancetypes/#versioning.
- Fix typo in `virtulmachineclusterinstancetype`
- Bump OCP must-gather image to 4.13 and HCO to 1.9.0.

Jira-ticket: https://issues.redhat.com/browse/CNV-30758

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable the collection of instancetypes by default and collect controllerrevisions that are associated with VMs.
```

