### PR TITLE
Add sleeps to automation/create_workloads.sh

### DIFF
--- a/automation/create_workloads.sh
+++ b/automation/create_workloads.sh
@@ -27,7 +27,23 @@ done
 
 # wait for the execution of the first 5 VMs
 for ns in {001..005}; do
-  ${CMD} wait -n "ns${ns}" vmi "testvm-ns${ns}-vm001" --for condition=Ready --timeout="300s"
+  found=false
+  for tries in {1..5}; do
+    if ${CMD} get -n "ns${ns}" vmi "testvm-ns${ns}-vm001"; then
+      found=true
+      break
+    else
+      echo "vmi ns${ns}/testvm-ns${ns}-vm001 does not exist yet. waiting 10 second"
+      sleep 10
+    fi
+  done
+
+  if [[ $found != "true" ]]; then
+    echo "vmi ns${ns}/testvm-ns${ns}-vm001 was not created"
+    exit 1
+  fi
+
+  ${CMD} wait -n "ns${ns}" vmi "testvm-ns${ns}-vm001" --for condition=Ready --timeout=300s
 done
 
 ${CMD} get vmis --all-namespaces


### PR DESCRIPTION
The e2e test fails from time to time, waiting for vmi that was not created yet.

This PR changes the script so it will retry reading the vmi before waiting for it to be ready.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

