### PR TITLE
Running gather scripts in background

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -84,12 +84,22 @@ Usage: oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gathe
 }
 
 function run_scripts {
+  # Store PIDs of all the subprocesses
+  pids=()
+  
   for script in "${requested_scripts[@]}";
   do
     script_name="gather_${script}"
     echo "running ${script_name}"
-    eval USR_BIN_GATHER=1 "${DIR_NAME}/${script_name}"
+    eval USR_BIN_GATHER=1 "${DIR_NAME}/${script_name}" &
+    pids+=($!)
   done
+
+  # Check if PID array has any values, if so, wait for them to finish
+  if [ ${#pids[@]} -ne 0 ]; then
+      echo "Waiting on subprocesses to finish execution."
+      wait "${pids[@]}"
+  fi
 }
 
 function run_logs {


### PR DESCRIPTION
The collection scripts can be executed in parallel to save time when running the MG.

Process:
1.Running gather scripts in parallel
2.Waiting for the subprocesses to finish execution.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

