### PR TITLE
Bump shellcheck to v0.10.0

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -21,10 +21,10 @@ jobs:
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       env:
-        SHELLCHECK_OPTS: -a -e SC2016 --source-path=./collection-scripts
+        SHELLCHECK_OPTS: -a -e SC2016 -e SC2317 --source-path=./collection-scripts
       with:
          check_together: 'yes'
-         version: v0.8.0
+         version: v0.10.0
          scandir: './collection-scripts/'
     - name: check vmConvertor
       run: |-

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: check-image-env docker-build docker-push
 
 # check
 check:
-	shellcheck -e SC2016 collection-scripts/*
+	shellcheck -a -e SC2016 -e SC2317 --source-path=./collection-scripts collection-scripts/*
 
 docker-build: check-image-env
 	docker build -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG} .

--- a/collection-scripts/version
+++ b/collection-scripts/version
@@ -16,7 +16,7 @@ function version() {
   # if version still not found, use Unknown
   [ -z "${version}" ] && version="Unknown"
 
-  echo ${version}
+  echo "${version}"
 }
 
 if [[ ! -f ${VERSION_FILE} ]]; then


### PR DESCRIPTION
- Bump shellcheck to v0.10.0
- explicitly disable SC2317 since it's reporting
  many false positives for us (we have helper functions
  that are only indirectly called in subshells for
  parallel executions but shellcheck is currently not able
  to follow them and so it's reporting the commands
  in the helper functions as unreachable)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

