### PR TITLE
automation/vm.yaml: replace cirros disk with alpine container disk demo

### DIFF
--- a/automation/vm.yaml
+++ b/automation/vm.yaml
@@ -42,14 +42,14 @@ spec:
             masquerade: {}
         resources:
           requests:
-            memory: 64M
+            memory: 128M
       networks:
       - name: default
         pod: {}
       volumes:
         - name: containerdisk
           containerDisk:
-            image: quay.io/kubevirt/cirros-container-disk-demo
+            image: quay.io/kubevirt/alpine-container-disk-demo:v1.6.0
         - name: cloudinitdisk
           cloudInitNoCloud:
             userDataBase64: SGkuXG4=


### PR DESCRIPTION
- Updated container disk image from `cirros-container-disk-demo` to `alpine-container-disk-demo:v1.6.0`, since cirros does not support s390x architecture.
- Alpine is used in most kubevirt tests as a replacement for cirros(https://github.com/kubevirt/kubevirt/issues/15043), with minimal differences in execution time and resource usage.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

