### PR TITLE
Add kubevirt-metrics-exporter metrics to --vm-incident collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,15 +281,20 @@ reflect the new instance, not the crash:
   `cpu.stat` (throttled time), `cpu.max`
 
 **Performance metrics** (`incident-metrics/`)
-- 26 Prometheus metrics exported in OpenMetrics format over the incident window (30 s step),
+- 33 Prometheus metrics exported in OpenMetrics format over the incident window (30 s step),
   covering VM, node, storage, and alert categories:
 
   | Category | Metrics |
   |---|---|
   | VM | CPU usage rate, resident memory, swap-in traffic, network TX/RX bytes and errors, disk read/write bytes and latency |
+  | VM (KME) | Per-disk I/O latency p99 and average, virtio-blk queue in-flight and capacity (QMP); guest-side I/O latency and IOPS (QGA, Windows) |
   | Node | CPU usage, available memory, CPU/memory/I/O pressure (PSI), disk I/O utilization, 1-min load average, network receive errors |
+  | Node (KME) | Block I/O latency p99, system block I/O latency p99, NFS I/O latency p99, NFS VFS call latency p99 (eBPF) |
   | Storage | PV usage %, volume mount duration, volume access-control duration |
   | Alerts | All firing KubeVirt alerts at incident time |
+
+  Metrics from kubevirt-metrics-exporter (KME) require the exporter to be deployed; when
+  absent, they are silently skipped and recorded in `metrics-metadata.json`.
 
 - `metrics-metadata.json` — which metrics were collected, which were skipped (with reasons),
   time window, and query step

--- a/collection-scripts/incident_metrics.conf
+++ b/collection-scripts/incident_metrics.conf
@@ -18,6 +18,16 @@ vm|storage_write_bytes|rate(kubevirt_vmi_storage_write_traffic_bytes_total{name=
 vm|storage_read_latency|rate(kubevirt_vmi_storage_read_times_seconds_total{name="$VM",namespace="$NS"}[5m])|VM disk read latency
 vm|storage_write_latency|rate(kubevirt_vmi_storage_write_times_seconds_total{name="$VM",namespace="$NS"}[5m])|VM disk write latency
 
+# --- KME: QMP per-disk storage metrics (kubevirt-metrics-exporter) ---
+vm|storage_io_latency_p99|histogram_quantile(0.99, rate(kubevirt_vmi_storage_io_latency_seconds_bucket{vmi="$VM",namespace="$NS"}[5m]))|VM per-disk I/O latency p99 (QMP)
+vm|storage_io_latency_avg|rate(kubevirt_vmi_storage_io_latency_seconds_sum{vmi="$VM",namespace="$NS"}[5m]) / rate(kubevirt_vmi_storage_io_latency_seconds_count{vmi="$VM",namespace="$NS"}[5m])|VM per-disk average I/O latency (QMP)
+vm|storage_queue_inuse|kubevirt_vmi_storage_queue_inuse{vmi="$VM",namespace="$NS"}|VM virtio-blk in-flight descriptors (QMP)
+vm|storage_queue_size|kubevirt_vmi_storage_queue_size{vmi="$VM",namespace="$NS"}|VM virtio-blk queue capacity (QMP)
+
+# --- KME: QGA guest-side storage metrics (Windows guests) ---
+vm|storage_guest_latency_avg|kubevirt_vmi_storage_guest_latency_avg_seconds{vmi="$VM",namespace="$NS"}|VM guest-side average I/O latency (QGA, Windows)
+vm|storage_guest_iops|kubevirt_vmi_storage_guest_iops{vmi="$VM",namespace="$NS"}|VM guest-side IOPS (QGA, Windows)
+
 # --- Node metrics (node_exporter) ---
 # node_exporter metrics use instance=<node_name> (relabeled from __meta_kubernetes_pod_node_name)
 node|cpu_usage|1 - avg without(cpu)(rate(node_cpu_seconds_total{mode="idle",instance="$NODE"}[5m]))|Node CPU usage
@@ -28,6 +38,12 @@ node|io_pressure|rate(node_pressure_io_stalled_seconds_total{instance="$NODE"}[5
 node|disk_io_util|rate(node_disk_io_time_seconds_total{instance="$NODE"}[5m])|Node disk I/O utilization
 node|load1|node_load1{instance="$NODE"}|Node 1-min load average
 node|net_receive_errors|rate(node_network_receive_errs_total{instance="$NODE"}[5m])|Node network receive errors
+
+# --- KME: eBPF block/NFS I/O metrics (kubevirt-metrics-exporter) ---
+node|block_io_latency_p99|histogram_quantile(0.99, rate(kme_block_io_latency_seconds_bucket{node="$NODE",namespace="$NS"}[5m]))|Block I/O latency p99 for namespace PVCs on node (eBPF)
+node|system_block_io_latency_p99|histogram_quantile(0.99, rate(kme_system_block_io_latency_seconds_bucket{node="$NODE"}[5m]))|System block I/O latency p99 on node (eBPF)
+node|nfs_io_latency_p99|histogram_quantile(0.99, rate(kme_nfs_io_latency_seconds_bucket{node="$NODE",namespace="$NS"}[5m]))|NFS I/O latency p99 for namespace PVCs on node (eBPF)
+node|nfs_vfs_latency_p99|histogram_quantile(0.99, rate(kme_nfs_vfs_latency_seconds_bucket{node="$NODE",namespace="$NS"}[5m]))|NFS VFS call latency p99 on node (eBPF)
 
 # --- Storage volume metrics (kubelet) ---
 storage|pv_usage_pct|kubelet_volume_stats_used_bytes{namespace="$NS"} / kubelet_volume_stats_capacity_bytes{namespace="$NS"} * 100|PV usage percentage


### PR DESCRIPTION
Add 10 new metrics from kubevirt-metrics-exporter (KME) to the incident metrics registry: QMP per-disk I/O latency (p99/avg) and virtio-blk queue stats, QGA guest-side latency and IOPS for Windows VMs, and eBPF block/NFS I/O latency (p99) on the incident node. Unavailable metrics (e.g. when KME is not deployed) are silently skipped. No code changes needed.

**Release note**:
```release-note
Add kubevirt-metrics-exporter metrics to --vm-incident collection
```

