### PR TITLE
Fix vm-incident OpenMetrics output: duplicate __name__ and HELP/TYPE declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,10 +338,56 @@ promtool tsdb create-blocks-from openmetrics incident-metrics.txt
 This creates TSDB blocks in a `data/` directory that can be copied into your Prometheus data
 directory. After restarting Prometheus, the historical metrics become queryable.
 
+If you don't have `promtool` installed locally, you can run the full workflow with Podman:
+import the metrics **and** start a throwaway Prometheus instance ready for Grafana.
+
+```sh
+# Create a working directory with the metrics file
+mkdir -p prom-backfill
+cp incident-metrics/incident-metrics.txt prom-backfill/
+
+# Generate TSDB blocks from the OpenMetrics file
+podman run --rm \
+  -v ./prom-backfill:/data:Z \
+  quay.io/prometheus/prometheus:latest \
+  promtool tsdb create-blocks-from openmetrics /data/incident-metrics.txt \
+  --output-dir /data/tsdb-blocks
+
+# Start a Prometheus instance serving the backfilled data
+podman run --rm -d --name prom-incident \
+  -p 9090:9090 \
+  -v ./prom-backfill/tsdb-blocks:/prometheus:Z \
+  quay.io/prometheus/prometheus:latest \
+  --storage.tsdb.path=/prometheus \
+  --storage.tsdb.retention.time=90d
+```
+
+Then point Grafana (or a browser) at `http://localhost:9090` to query the incident
+metrics. When done, stop the container with `podman stop prom-incident`.
+
 **VictoriaMetrics**:
 ```sh
 curl -X POST 'http://localhost:8428/api/v1/import/prometheus' \
   --data-binary @incident-metrics.txt
+```
+
+Or with Podman:
+
+```sh
+# Start a throwaway VictoriaMetrics instance
+podman run --rm -d --name vm-incident \
+  -p 8428:8428 \
+  -v vm-incident-data:/victoria-metrics-data:Z \
+  docker.io/victoriametrics/victoria-metrics:stable
+
+# Import the metrics
+curl -X POST 'http://localhost:8428/api/v1/import/prometheus' \
+  --data-binary @incident-metrics/incident-metrics.txt
+
+# Query at http://localhost:8428/vmui
+# When done:
+podman stop vm-incident
+podman volume rm vm-incident-data
 ```
 
 #### Workflow

--- a/collection-scripts/gather_vm_incident
+++ b/collection-scripts/gather_vm_incident
@@ -99,14 +99,15 @@ collect_incident_metrics() {
         fi
 
         if echo "${response}" | jq -r --arg slug "${slug}" --arg desc "${description}" '
-            "# HELP " + $slug + " " + $desc,
-            "# TYPE " + $slug + " gauge",
+            (.data.result[0].metric.__name__ // $slug) as $name |
+            "# HELP " + $name + " " + $desc,
+            "# TYPE " + $name + " gauge",
             (
                 .data.result[] |
                 .metric as $m |
-                ($m | to_entries | map(.key + "=\"" + .value + "\"") | join(",")) as $labels |
+                ($m | to_entries | map(select(.key != "__name__")) | map(.key + "=\"" + .value + "\"") | join(",")) as $labels |
                 .values[] |
-                $slug + "{" + $labels + "} " + .[1] + " " + (.[0] | tostring)
+                $name + "{" + $labels + "} " + .[1] + " " + (.[0] | tostring)
             )
         ' >> "${metrics_file}" 2>/dev/null; then
             ok=$(( ok + 1 ))

--- a/collection-scripts/incident_metrics.conf
+++ b/collection-scripts/incident_metrics.conf
@@ -20,7 +20,7 @@ vm|storage_write_latency|rate(kubevirt_vmi_storage_write_times_seconds_total{nam
 
 # --- Node metrics (node_exporter) ---
 # node_exporter metrics use instance=<node_name> (relabeled from __meta_kubernetes_pod_node_name)
-node|cpu_usage|1 - avg without(cpu)(rate(node_cpu_seconds_total{mode="idle",instance="$NODE"}[5m]))|Node CPU usage
+node|node_cpu_usage|1 - avg without(cpu)(rate(node_cpu_seconds_total{mode="idle",instance="$NODE"}[5m]))|Node CPU usage
 node|memory_available|node_memory_MemAvailable_bytes{instance="$NODE"}|Node available memory bytes
 node|cpu_pressure|rate(node_pressure_cpu_waiting_seconds_total{instance="$NODE"}[5m])|Node CPU pressure (PSI)
 node|memory_pressure|rate(node_pressure_memory_stalled_seconds_total{instance="$NODE"}[5m])|Node memory pressure (PSI)

--- a/tests/validate_must_gather_test.go
+++ b/tests/validate_must_gather_test.go
@@ -1086,11 +1086,27 @@ var _ = Describe("validate the must-gather output", func() {
 			Expect(err).ToNot(HaveOccurred())
 			metricsStr := string(metricsContent)
 
+			// For direct-selector queries Prometheus returns __name__ which
+			// is used as the metric name instead of the slug.  Verify each
+			// collected metric has a HELP/TYPE line under either name.
 			for _, m := range metadata.Items {
-				Expect(metricsStr).To(ContainSubstring("# HELP "+m.Slug),
-					fmt.Sprintf("metrics file should contain HELP line for collected metric %s/%s", m.Category, m.Slug))
-				Expect(metricsStr).To(MatchRegexp(`# TYPE `+regexp.QuoteMeta(m.Slug)+` (gauge|counter|histogram|summary)`),
-					fmt.Sprintf("metrics file should contain TYPE line for collected metric %s/%s", m.Category, m.Slug))
+				helpBySlug := strings.Contains(metricsStr, "# HELP "+m.Slug+" ")
+				helpByConf := false
+				for _, line := range strings.Split(string(confContent), "\n") {
+					parts := strings.SplitN(line, "|", 4)
+					if len(parts) >= 3 && parts[1] == m.Slug {
+						query := strings.TrimSpace(parts[2])
+						// extract the leading metric name from the PromQL template
+						promName := strings.SplitN(query, "{", 2)[0]
+						promName = strings.SplitN(promName, "(", 2)[0]
+						if strings.Contains(metricsStr, "# HELP "+promName+" ") {
+							helpByConf = true
+						}
+						break
+					}
+				}
+				Expect(helpBySlug || helpByConf).To(BeTrue(),
+					fmt.Sprintf("metrics file should contain a HELP line for collected metric %s/%s (by slug or original Prometheus name)", m.Category, m.Slug))
 			}
 
 			for _, s := range metadata.Skipped {
@@ -1099,6 +1115,95 @@ var _ = Describe("validate the must-gather output", func() {
 
 			logger.Printf("  metrics accounting: %d total (%d collected, %d skipped)",
 				metadata.Total, metadata.Collected, len(metadata.Skipped))
+		})
+
+		It("should produce valid OpenMetrics with no __name__ label in data lines", func() {
+			metricsFile := path.Join(incidentDir, "incident-metrics", "incident-metrics.txt")
+			content, err := os.ReadFile(metricsFile)
+			Expect(err).ToNot(HaveOccurred(), "incident-metrics.txt should be readable")
+
+			namePattern := regexp.MustCompile(`__name__\s*=`)
+			violations := []string{}
+			for i, line := range strings.Split(string(content), "\n") {
+				if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+					continue
+				}
+				if namePattern.MatchString(line) {
+					violations = append(violations, fmt.Sprintf("  line %d: %s", i+1, line[:min(len(line), 120)]))
+				}
+			}
+			Expect(violations).To(BeEmpty(),
+				"OpenMetrics data lines must not contain an explicit __name__ label "+
+					"(the metric name before '{' already serves as __name__). Violations:\n"+
+					strings.Join(violations, "\n"))
+			logger.Printf("  scanned %d lines for __name__ violations — none found", len(strings.Split(string(content), "\n")))
+		})
+
+		It("should have no duplicate HELP or TYPE declarations for the same metric name", func() {
+			metricsFile := path.Join(incidentDir, "incident-metrics", "incident-metrics.txt")
+			content, err := os.ReadFile(metricsFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			helpCounts := map[string]int{}
+			typeCounts := map[string]int{}
+			for _, line := range strings.Split(string(content), "\n") {
+				if strings.HasPrefix(line, "# HELP ") {
+					parts := strings.SplitN(strings.TrimPrefix(line, "# HELP "), " ", 2)
+					if len(parts) >= 1 {
+						helpCounts[parts[0]]++
+					}
+				}
+				if strings.HasPrefix(line, "# TYPE ") {
+					parts := strings.SplitN(strings.TrimPrefix(line, "# TYPE "), " ", 2)
+					if len(parts) >= 1 {
+						typeCounts[parts[0]]++
+					}
+				}
+			}
+
+			duplicates := []string{}
+			for name, count := range helpCounts {
+				if count > 1 {
+					duplicates = append(duplicates, fmt.Sprintf("  # HELP %s appears %d times", name, count))
+				}
+			}
+			for name, count := range typeCounts {
+				if count > 1 {
+					duplicates = append(duplicates, fmt.Sprintf("  # TYPE %s appears %d times", name, count))
+				}
+			}
+			Expect(duplicates).To(BeEmpty(),
+				"OpenMetrics requires unique HELP/TYPE declarations per metric name. Duplicates:\n"+
+					strings.Join(duplicates, "\n"))
+		})
+
+		It("should have unique slugs in incident_metrics.conf", func() {
+			confPath := path.Join(incidentDir, "incident-metrics", "incident_metrics.conf")
+			confContent, err := os.ReadFile(confPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			slugCounts := map[string]int{}
+			for _, line := range strings.Split(string(confContent), "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" || strings.HasPrefix(line, "#") {
+					continue
+				}
+				parts := strings.SplitN(line, "|", 4)
+				if len(parts) >= 2 {
+					slugCounts[parts[1]]++
+				}
+			}
+
+			duplicates := []string{}
+			for slug, count := range slugCounts {
+				if count > 1 {
+					duplicates = append(duplicates, fmt.Sprintf("  slug %q appears %d times", slug, count))
+				}
+			}
+			Expect(duplicates).To(BeEmpty(),
+				"incident_metrics.conf slugs must be unique — duplicates produce invalid OpenMetrics "+
+					"(duplicate HELP/TYPE declarations). Duplicates:\n"+
+					strings.Join(duplicates, "\n"))
 		})
 
 		It("should collect virsh and QEMU data when VM has not restarted", func() {


### PR DESCRIPTION
The incident metrics jq conversion included __name__ from Prometheus API responses as an explicit label, duplicating the metric name already present before '{'. This caused promtool and VictoriaMetrics to reject the file. Additionally, the slug "cpu_usage" was used for both vm and node categories, producing duplicate HELP/TYPE declarations.

Fix the jq expression to filter __name__ from labels and use the original Prometheus metric name (from __name__) when available, falling back to the slug for rate/aggregation queries.

Rename the node cpu_usage slug to node_cpu_usage.

Add tests for __name__ in data lines, duplicate HELP/TYPE declarations, and slug uniqueness.

Expand README backfilling docs with Podman workflows for Prometheus and VictoriaMetrics.

Fixes: CNV-94708

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix vm-incident OpenMetrics output: duplicate __name__ and HELP/TYPE declarations
```

