### PR TITLE
incident-metrics: fix storage latency calculation and add IOPS metrics

### DIFF
--- a/collection-scripts/incident_metrics.conf
+++ b/collection-scripts/incident_metrics.conf
@@ -15,8 +15,10 @@ vm|net_tx_errors|rate(kubevirt_vmi_network_transmit_errors_total{name="$VM",name
 vm|net_rx_errors|rate(kubevirt_vmi_network_receive_errors_total{name="$VM",namespace="$NS"}[5m])|VM network RX errors
 vm|storage_read_bytes|rate(kubevirt_vmi_storage_read_traffic_bytes_total{name="$VM",namespace="$NS"}[5m])|VM disk read rate
 vm|storage_write_bytes|rate(kubevirt_vmi_storage_write_traffic_bytes_total{name="$VM",namespace="$NS"}[5m])|VM disk write rate
-vm|storage_read_latency|rate(kubevirt_vmi_storage_read_times_seconds_total{name="$VM",namespace="$NS"}[5m])|VM disk read latency
-vm|storage_write_latency|rate(kubevirt_vmi_storage_write_times_seconds_total{name="$VM",namespace="$NS"}[5m])|VM disk write latency
+vm|storage_read_iops|rate(kubevirt_vmi_storage_iops_read_total{name="$VM",namespace="$NS"}[5m])|VM disk read IOPS
+vm|storage_write_iops|rate(kubevirt_vmi_storage_iops_write_total{name="$VM",namespace="$NS"}[5m])|VM disk write IOPS
+vm|storage_read_latency_avg|rate(kubevirt_vmi_storage_read_times_seconds_total{name="$VM",namespace="$NS"}[5m]) / rate(kubevirt_vmi_storage_iops_read_total{name="$VM",namespace="$NS"}[5m]) * 1000|VM disk read latency ms per op
+vm|storage_write_latency_avg|rate(kubevirt_vmi_storage_write_times_seconds_total{name="$VM",namespace="$NS"}[5m]) / rate(kubevirt_vmi_storage_iops_write_total{name="$VM",namespace="$NS"}[5m]) * 1000|VM disk write latency ms per op
 
 # --- Node metrics (node_exporter) ---
 # node_exporter metrics use instance=<node_name> (relabeled from __meta_kubernetes_pod_node_name)


### PR DESCRIPTION
The storage_read_latency and storage_write_latency metrics in incident_metrics.conf were previously defined as:

`rate(kubevirt_vmi_storage_write_times_seconds_total[5m])
`

This computes I/O utilization (seconds of I/O time per wall-clock second), not actual latency. The value represents how busy the disk is, and with parallel I/O, it is not much helpful and will be misleading during RCA.

For example, I did a FIO from the VM and got following results:

```
# fio --name=test-io --filename=/dev/vda --rw=randread --bs=16k --iodepth=64 --ioengine=libaio --direct=1 --runtime=300 --time_based --readonly --group_reporting
grub-like: (g=0): rw=randread, bs=(R) 16.0KiB-16.0KiB, (W) 16.0KiB-16.0KiB, (T) 16.0KiB-16.0KiB, ioengine=libaio, iodepth=64
fio-3.35
Starting 1 process

Jobs: 1 (f=1): [r(1)][100.0%][r=842MiB/s][r=53.9k IOPS][eta 00m:00s]
test-io: (groupid=0, jobs=1): err= 0: pid=6928: Thu Aug  6 10:27:35 2026
  read: IOPS=53.8k, BW=841MiB/s (882MB/s)(246GiB/300008msec)
    slat (usec): min=3, max=1133, avg= 5.36, stdev= 3.80
    clat (usec): min=2, max=46821, avg=1182.68, stdev=3317.46
     lat (usec): min=29, max=46827, avg=1188.05, stdev=3317.46
```

Following is the graph I got for the read latency:

<img width="2298" height="513" alt="storage_latency_old" src="https://github.com/user-attachments/assets/4a957bee-939c-4b5e-a8cb-4b6f8af8383e" />


A value of 30-60  doesn't help much without the IOPS denominator. It can be

30,000 fast ops at 1ms each, or
30 slow ops at 1000ms each

### Fix

Added storage_read_iops and storage_write_iops metrics to collect VM disk IOPS (kubevirt_vmi_storage_iops_{read,write}_total), enabling independent visibility into I/O throughput. This is helpful to see if there is spike in IOPS.

Changed storage_read_latency and storage_write_latency to compute actual per-operation latency in ms:

`rate(times_seconds_total[5m]) / rate(iops_total[5m]) * 1000
`

The result is now in milliseconds per I/O operation, directly comparable to fio output and standard latency measurements.

For the same above fio result, it now shows following outputs, where average latency shows around 1.1 ms which matches with fio output:

<img width="2294" height="505" alt="storage_read_iops" src="https://github.com/user-attachments/assets/8fd5a019-c6fd-453d-b5e4-a0c5bb4257b9" />
<img width="2298" height="513" alt="storage_read_latency" src="https://github.com/user-attachments/assets/9024051d-5583-4c8d-94db-b466ed516a26" />


**Release note**:
```release-note
incident-metrics: fix storage latency calculation and add IOPS metrics
```

