### PR TITLE
Collect virt-handler ghost record checkpoints in must-gather

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You will get a dump of:
 - The Hyperconverged Cluster Operator namespaces (and its children objects)
 - All namespaces (and their children objects) that belong to any KubeVirt resources
 - All KubeVirt CRD's definitions
-- Per-node system and storage diagnostics (dmesg, dmidecode, sysctl, NFS config, PSI counters, kernel red-flag scan)
+- Per-node system and storage diagnostics (dmesg, dmidecode, sysctl, NFS config, PSI counters, kernel red-flag scan, virt-handler ghost records)
 - CNV guest events (GuestPanicked, LivenessProbeFailed) across VM namespaces
 - Prometheus instant metrics (cluster utilization, VM phases, storage latencies, NFS counters)
 - ClusterRole definitions (cluster-reader posture, KubeVirt RBAC baseline)
@@ -247,6 +247,11 @@ Everything below is scoped to the incident node and time window — no cluster-w
 - `/proc/mounts` — mount table
 - NFS client config (`nfs.conf`, module parameters, modprobe rules)
 
+**virt-handler ghost records** (`nodes/<node>/kubevirt-private/ghost-records/`)
+- Per-VMI checkpoint files (one JSON file per UID) persisted by virt-handler on the node
+- Maps VMIs to libvirt domain sockets; useful for debugging stale domains and missing checkpoints
+- Collected from the host via node-gather; falls back to the virt-handler pod when node-gather is unavailable
+
 **Cluster health snapshot** (`cluster-scoped-resources/`)
 - ClusterOperators, nodes overview, MachineConfigPools
 - `oc adm top node` for the incident node
@@ -264,6 +269,7 @@ Everything below is scoped to the incident node and time window — no cluster-w
 **Pod logs** (`namespaces/<ns>/core/pods/`)
 - virt-launcher pod: all containers, current and previous logs (captures crash output)
 - virt-handler pod on the incident node: current and previous logs
+- virt-handler ghost record checkpoint files on the incident node (see above)
 
 **Live VM state** (`namespaces/<ns>/vms/<vm>/`) — only if the VM has NOT restarted since the
 incident; skipped automatically when the pod postdates the incident, since that data would

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -85,3 +85,22 @@ query_prometheus_range() {
 	echo "${result}"
 	eval "$_xtrace"
 }
+
+# Collect virt-handler ghost record checkpoint files via a node-gather pod.
+# Ghost records are on the host under /run/kubevirt-private/ghost-records; node-gather
+# mounts host /run at /host/run.
+# Args: <node_gather_pod> <dest_node_path>
+collect_virt_handler_ghost_records() {
+	local node_gather_pod="$1"
+	local node_path="$2"
+	local ghost_dir="/host/run/kubevirt-private/ghost-records"
+
+	if ! timeout 10 /usr/bin/oc exec "${node_gather_pod}" -n node-gather -- \
+		[ -d "${ghost_dir}" ] 2>/dev/null; then
+		return 1
+	fi
+
+	mkdir -p "${node_path}/kubevirt-private"
+	timeout 60 oc cp "${node_gather_pod}:${ghost_dir}/." "${node_path}/kubevirt-private/ghost-records/" \
+		-n node-gather 2>/dev/null || true
+}

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -112,7 +112,8 @@ Usage: oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gathe
     Requires NS and VM environment variables. Skips all other collectors.
     Automatically identifies the node via Prometheus metrics and collects:
     - Host: dmesg, journal, kubelet, dmidecode, sysctl, chrony, ip config,
-      storage diagnostics (mountstats, diskstats, PSI), NFS config, kernel red-flags
+      storage diagnostics (mountstats, diskstats, PSI), NFS config, kernel red-flags,
+      virt-handler ghost records
     - Cluster: ClusterOperators, nodes, MachineConfigPools, KubeVirt version,
       VMIs on incident node (noisy-neighbor detection)
     - VM: definitions, PVC/PV/StorageClass/DataVolume chain, namespace events

--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -13,7 +13,8 @@
 #   df,mounts,mountstats,diskstats,pressure_*,nfs_module_params,nfs.conf,nfs_modprobe,
 #   nfs_sysctl,nfs_sysfs,nfs_slot_tuning_service,nfs_mountstats_delays,tuned_*,
 #   kernel_red_flags.log,bridge,vlan,nftables,sys_sriov_numvfs,sys_sriov_totalvfs,
-#   dev_vfio,opt-cni-bin,var-lib-cni-bin,pcidp_config.json,audit.log}
+#   dev_vfio,opt-cni-bin,var-lib-cni-bin,pcidp_config.json,audit.log,
+#   kubevirt-private/ghost-records/<vmi-uid>}
 
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # shellcheck source=common.sh
@@ -291,6 +292,8 @@ collect_node() {
     if timeout 10 /usr/bin/oc exec "${NODE_GATHER_POD}" -n node-gather -- [ -f /host/etc/pcidp/config.json ] 2>/dev/null; then
         timeout 60 oc cp "${NODE_GATHER_POD}:/host/etc/pcidp/config.json" "${NODE_PATH}/pcidp_config.json" -n node-gather 2>/dev/null || true
     fi
+
+    collect_virt_handler_ghost_records "${NODE_GATHER_POD}" "${NODE_PATH}"
 
     # audit.log can be hundreds of MB; skip in incident mode, cap at 50 MB in default mode
     if [[ -z "${TARGET_NODE}" ]]; then

--- a/node-gather/node-gather-ds.yaml
+++ b/node-gather/node-gather-ds.yaml
@@ -57,6 +57,8 @@ spec:
             mountPath: /host/opt
           - name: var
             mountPath: /host/var            
+          - name: run
+            mountPath: /host/run
         securityContext:
           privileged: true
       volumes:
@@ -83,5 +85,9 @@ spec:
       - name: var
         hostPath:
           path: /var
+          type: Directory
+      - name: run
+        hostPath:
+          path: /run
           type: Directory
 


### PR DESCRIPTION
virt-handler persists VMI-to-domain mappings as JSON checkpoint files on each node under /run/kubevirt-private/ghost-records. These records are written when a VMI is started and removed when it is fully torn down. Gathering them in support bundles helps debug stale domains, missing checkpoints, virt-handler restarts, and VMI/domain mismatches.

Add shared collection helpers and wire them into the existing node gathering flow:

- common.sh: add collect_virt_handler_ghost_records() to copy checkpoint files from the node-gather pod via the host path /host/run/kubevirt-private/ghost-records
- gather_nodes: collect ghost records for each node during per-node diagnostics

Each checkpoint file is copied individually (one file per VMI UID), preserving the on-disk format used by virt-handler's checkpoint manager. No aggregation or transformation is performed.

Collected artifacts are stored at:
```
  nodes/<node>/kubevirt-private/ghost-records/<vmi-uid>.json
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
collect virt-handler ghost record checkpoints in must-gather
```

