### PR TITLE
vm-incident: map PVC/PV volumeHandle to host block device (WWID-anchored)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,31 @@ Everything below is scoped to the incident node and time window — no cluster-w
 - VolumeAttachments for the incident node
 - Namespace events (FailedAttach, FailedMount, etc.)
 
+**Storage device mapping** (`namespaces/<ns>/vms/<vm>/storage-device-mapping.{txt,json}`)
+
+Bridges each VM volume to the physical block device on the incident node, so support can
+attribute node-wide storage events (multipath path flap, high `disk_io_util`, dm/sd latency)
+to the specific VM instead of flagging it as an unresolvable gap. The full chain:
+
+```
+PVC → PV → csi.volumeHandle → host dm-*/sd* device → WWID / multipath name / underlying SCSI paths
+```
+
+The host device is resolved on the node (via the node-gather pod) through the kubelet CSI
+publish/staging path for block-mode volumes, and the kubelet mount table for filesystem-mode
+volumes — matched by device major:minor, so it works regardless of how the CSI driver named
+the device. Network/file-backed volumes (e.g. NFS) are reported with their source instead of a
+block device. Supporting raw node inventory is written under `nodes/<node>/`:
+
+- `block_devices`, `block_devices.json` — `lsblk` with `WWN`, `SERIAL`, `HCTL`
+- `multipath` — `multipath -ll` (device-mapper multipath topology and WWIDs)
+- `dev_disk_by_id`, `dev_disk_by_path` — stable device link tables
+- `dmsetup` — device-mapper tree
+- `pv_device_resolution` — raw per-PV → device resolution records
+
+Each mapping lists the `device="dm-*"` label to use when filtering the node metrics in
+`incident-metrics/`, closing the loop from a VM to a node-wide I/O event.
+
 **Pod logs** (`namespaces/<ns>/core/pods/`)
 - virt-launcher pod: all containers, current and previous logs (captures crash output)
 - virt-handler pod on the incident node: current and previous logs
@@ -281,15 +306,22 @@ reflect the new instance, not the crash:
   `cpu.stat` (throttled time), `cpu.max`
 
 **Performance metrics** (`incident-metrics/`)
-- 26 Prometheus metrics exported in OpenMetrics format over the incident window (30 s step),
+- 28 Prometheus metrics exported in OpenMetrics format over the incident window (30 s step),
   covering VM, node, storage, and alert categories:
 
   | Category | Metrics |
   |---|---|
   | VM | CPU usage rate, resident memory, swap-in traffic, network TX/RX bytes and errors, disk read/write bytes and latency |
   | Node | CPU usage, available memory, CPU/memory/I/O pressure (PSI), disk I/O utilization, 1-min load average, network receive errors |
-  | Storage | PV usage %, volume mount duration, volume access-control duration |
+  | Storage | PV usage %, volume mount/access-control duration, per-device I/O utilization, read/write latency, in-flight queue depth, and `node_disk_info` (device↔WWID map) |
   | Alerts | All firing KubeVirt alerts at incident time |
+
+  The `node_disk_info` series is what makes the storage device mapping usable historically:
+  the `dm-*`/`sd*` names in `storage-device-mapping.txt` are resolved at collection time, but
+  a multipath device is 1:N over its SCSI paths and those kernel names can be reassigned across
+  a rescan or reboot. `node_disk_info{wwn=...}` records the device↔WWID association **as scraped
+  at incident time**, so a stable WWID can always be mapped back to the incident-time `device`
+  label used by the per-device I/O and latency metrics.
 
 - `metrics-metadata.json` — which metrics were collected, which were skipped (with reasons),
   time window, and query step

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -6,7 +6,7 @@ export PROS=${PROS:-5}
 export INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-kubevirt-hyperconverged}
 
 # Shared kernel red-flag grep pattern — used by gather_nodes and gather_vm_incident
-export KERNEL_REDFLAG_PATTERN='nfs:|NFS |nfs |NFSERR|server not responding|zero writ|call_transmit|cb path stale|not responding for|qemu|QEMU|Out of memory|oom-kill|Killed process.*qemu|task .* blocked|blocked for more than|stuck for|jiffies'
+export KERNEL_REDFLAG_PATTERN='nfs:|NFS |nfs |NFSERR|server not responding|zero writ|call_transmit|cb path stale|not responding for|qemu|QEMU|Out of memory|oom-kill|Killed process.*qemu|task .* blocked|blocked for more than|stuck for|jiffies|multipath|device-mapper: multipath|failing path|reinstating path|remaining active paths|marginal path|Buffer I/O error|blk_update_request|I/O error, dev|rejecting I/O to offline device|scsi_eh|SCSI error|rport-.* blocked|FC remote port'
 
 function check_command {
     if [[ -z "$USR_BIN_GATHER" ]]; then

--- a/collection-scripts/gather_vm_incident
+++ b/collection-scripts/gather_vm_incident
@@ -141,6 +141,288 @@ collect_incident_metrics() {
     set -x
 }
 
+# Bridge the VM's PVCs/PVs to the physical block devices on the incident node so
+# support can attribute node-wide storage events (multipath flap, disk_io_util,
+# high-latency dm-*/sd*) to this specific VM instead of flagging an unresolvable gap.
+#
+# Chain: PVC -> PV -> csi.volumeHandle -> host dm-*/sd* device -> WWID / multipath paths
+#
+# The reliable node-side link is the kubelet CSI publish/staging path, which resolves
+# (via device major:minor) to the real kernel device regardless of how the CSI driver
+# named it. Block-mode volumes resolve through .../csi/volumeDevices/, filesystem-mode
+# volumes through the kubelet mount table (/proc/mounts). Requires the node-gather pod;
+# without it, only the cluster-side PV/volumeHandle metadata is recorded.
+collect_storage_device_mapping() {
+    echo "Mapping VM storage to host block devices (PVC/PV -> volumeHandle -> device)..."
+    local map_dir="${BASE_COLLECTION_PATH}/namespaces/${NS}/vms/${VM}"
+    local node_path="${BASE_COLLECTION_PATH}/nodes/${INCIDENT_NODE}"
+    mkdir -p "${map_dir}" "${node_path}"
+    local report="${map_dir}/storage-device-mapping.txt"
+    local json_out="${map_dir}/storage-device-mapping.json"
+    local tsv
+    tsv=$(mktemp)
+
+    { set +x; } 2>/dev/null
+
+    # --- Cluster side: enumerate the VM's PVCs -> PVs ---
+    local pvcs
+    pvcs=$(timeout 30 /usr/bin/oc get vm "${VM}" -n "${NS}" --request-timeout=30s \
+        -o jsonpath='{range .spec.template.spec.volumes[*]}{.persistentVolumeClaim.claimName}{"\n"}{.dataVolume.name}{"\n"}{end}' 2>/dev/null \
+        | grep -v '^$' | sort -u)
+
+    if [[ -z "${pvcs}" ]]; then
+        echo "  No PVCs found for VM ${VM}; skipping device mapping."
+        skipped "storage device mapping (no PVCs found for VM)"
+        rm -f "${tsv}"
+        set -x
+        return
+    fi
+
+    local -A PV_OF_PVC
+    local pv_list=()
+    local pvc pv
+    while read -r pvc; do
+        [[ -z "${pvc}" ]] && continue
+        pv=$(timeout 30 /usr/bin/oc get pvc "${pvc}" -n "${NS}" --request-timeout=30s -o jsonpath='{.spec.volumeName}' 2>/dev/null)
+        [[ -z "${pv}" ]] && continue
+        PV_OF_PVC["${pvc}"]="${pv}"
+        pv_list+=("${pv}")
+    done <<< "${pvcs}"
+
+    # VolumeAttachments (one query, filtered per-PV below)
+    local va_json
+    va_json=$(timeout 30 /usr/bin/oc get volumeattachments -o json --request-timeout=30s 2>/dev/null)
+
+    # --- Node side: resolve each PV to its host block device ---
+    # Emits, per PV: "DEV\t<pv>\t<devpath>\t<maj:min>\t<kname>\t<wwid>\t<mpath>\t<slaves>",
+    # "NET\t<pv>\t<source>" for network/file-backed volumes, or "NODEV\t<pv>".
+    local node_resolve_script
+    node_resolve_script=$(cat <<'EOS'
+set +e
+devrow() {
+    local pv="$1" src="$2" real hex majmin kname wwid mpath slaves l
+    real=$(readlink -f "$src" 2>/dev/null)
+    [ -b "$real" ] || return 0
+    hex=$(stat -L -c '%t:%T' "$real" 2>/dev/null)
+    [ -n "$hex" ] || return 0
+    majmin=$(( 16#${hex%%:*} )):$(( 16#${hex##*:} ))
+    kname=$(basename "$(readlink -f "/sys/dev/block/${majmin}" 2>/dev/null)" 2>/dev/null)
+    [ -n "$kname" ] || return 0
+    mpath=$(dmsetup info -c --noheadings -o name "$kname" 2>/dev/null)
+    wwid=$(dmsetup info -c --noheadings -o uuid "$kname" 2>/dev/null)
+    if [ -z "$wwid" ]; then
+        for l in /dev/disk/by-id/*; do
+            [ -e "$l" ] || continue
+            [ "$(basename "$(readlink -f "$l" 2>/dev/null)")" = "$kname" ] || continue
+            case "$(basename "$l")" in
+                wwn-*|scsi-3*|nvme-eui*|dm-uuid-*) wwid=$(basename "$l"); break ;;
+            esac
+        done
+    fi
+    slaves=$(ls "/sys/block/${kname}/slaves" 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
+    printf 'DEV\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$pv" "$real" "$majmin" "$kname" "$wwid" "$mpath" "$slaves"
+    return 1
+}
+for pv in "$@"; do
+    found=0
+    for base in \
+        "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/${pv}" \
+        "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/${pv}" \
+        "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/${pv}"; do
+        [ -e "$base" ] || continue
+        while IFS= read -r p; do
+            devrow "$pv" "$p" || found=1
+        done < <(find "$base" -mindepth 1 -maxdepth 4 2>/dev/null)
+    done
+    while read -r src mnt _; do
+        case "$mnt" in
+            *"/${pv}/"*|*"/${pv}")
+                if [ "${src#/dev/}" != "$src" ]; then
+                    devrow "$pv" "$src" || found=1
+                else
+                    printf 'NET\t%s\t%s\n' "$pv" "$src"; found=1
+                fi ;;
+        esac
+    done < /proc/mounts
+    [ "$found" -eq 0 ] && printf 'NODEV\t%s\n' "$pv"
+done
+EOS
+)
+
+    local resolution=""
+    if [[ -n "${NODE_GATHER_POD}" && ${#pv_list[@]} -gt 0 ]]; then
+        echo "  Collecting host block-device inventory from ${INCIDENT_NODE}..."
+        timeout 60 /usr/bin/oc exec "${NODE_GATHER_POD}" -n node-gather -- nsenter --mount=/host/proc/1/ns/mnt -- \
+            lsblk -o NAME,KNAME,TYPE,SIZE,FSTYPE,MOUNTPOINT,WWN,SERIAL,HCTL,VENDOR,MODEL 2>/dev/null \
+            > "${node_path}/block_devices"
+        timeout 60 /usr/bin/oc exec "${NODE_GATHER_POD}" -n node-gather -- nsenter --mount=/host/proc/1/ns/mnt -- \
+            lsblk -O -J 2>/dev/null > "${node_path}/block_devices.json"
+        timeout 60 /usr/bin/oc exec "${NODE_GATHER_POD}" -n node-gather -- nsenter --mount=/host/proc/1/ns/mnt -- \
+            multipath -ll 2>/dev/null > "${node_path}/multipath"
+        timeout 60 /usr/bin/oc exec "${NODE_GATHER_POD}" -n node-gather -- nsenter --mount=/host/proc/1/ns/mnt -- \
+            /bin/bash -c 'ls -l /dev/disk/by-id 2>/dev/null' > "${node_path}/dev_disk_by_id"
+        timeout 60 /usr/bin/oc exec "${NODE_GATHER_POD}" -n node-gather -- nsenter --mount=/host/proc/1/ns/mnt -- \
+            /bin/bash -c 'ls -l /dev/disk/by-path 2>/dev/null' > "${node_path}/dev_disk_by_path"
+        timeout 60 /usr/bin/oc exec "${NODE_GATHER_POD}" -n node-gather -- nsenter --mount=/host/proc/1/ns/mnt -- \
+            /bin/bash -c 'dmsetup ls --tree 2>/dev/null; echo "--- dmsetup info ---"; dmsetup info -c 2>/dev/null' \
+            > "${node_path}/dmsetup"
+        # Drop empty artifacts (e.g. multipath not configured on this host)
+        for f in block_devices block_devices.json multipath dev_disk_by_id dev_disk_by_path dmsetup; do
+            [[ -s "${node_path}/${f}" ]] || rm -f "${node_path}/${f}"
+        done
+
+        echo "  Resolving PV -> host device for ${#pv_list[@]} volume(s)..."
+        resolution=$(timeout 90 /usr/bin/oc exec "${NODE_GATHER_POD}" -n node-gather -- nsenter --mount=/host/proc/1/ns/mnt -- \
+            /bin/bash -c "${node_resolve_script}" bash "${pv_list[@]}" 2>/dev/null)
+        printf '%s\n' "${resolution}" > "${node_path}/pv_device_resolution"
+    else
+        echo "  WARNING: node-gather pod unavailable; recording cluster-side PV/volumeHandle metadata only."
+    fi
+
+    # Index node resolution by PV (dedup DEV rows by kname, keep NET sources)
+    local -A DEVROWS NETROWS
+    if [[ -n "${resolution}" ]]; then
+        local tag rpv rpath rmm rkname rwwid rmpath rslaves
+        while IFS=$'\t' read -r tag rpv rpath rmm rkname rwwid rmpath rslaves; do
+            case "${tag}" in
+                DEV)
+                    [[ "${DEVROWS[${rpv}]}" == *"|${rkname}|"* ]] && continue
+                    DEVROWS[${rpv}]+="|${rkname}|	${rpath}	${rmm}	${rkname}	${rwwid}	${rmpath}	${rslaves}"$'\n'
+                    ;;
+                NET)
+                    [[ "${NETROWS[${rpv}]}" == *"${rpath}"$'\n'* ]] && continue
+                    NETROWS[${rpv}]+="${rpath}"$'\n'
+                    ;;
+            esac
+        done <<< "${resolution}"
+    fi
+
+    # --- Assemble report + TSV ---
+    {
+        echo "VM storage -> host block device mapping"
+        echo "========================================"
+        echo "VM:            ${NS}/${VM}"
+        echo "Node:          ${INCIDENT_NODE}"
+        echo "Incident time: ${INCIDENT_TIME}"
+        echo ""
+        echo "STABLE KEY: use the WWID to attribute node-wide storage events to this VM."
+        echo "The dm-*/sd* kernel names below are point-in-time (resolved at must-gather"
+        echo "collection, which may be hours after the incident). A multipath device is 1:N"
+        echo "over its SCSI paths, and both dm-* and sd* names can be reassigned across a"
+        echo "path rescan, reboot, or live-migration — so a name seen in the incident-time"
+        echo "journal/metrics is only trustworthy when cross-checked against the WWID."
+        echo ""
+        echo "How to correlate:"
+        echo "  1. Take the WWID for this VM's volume below."
+        echo "  2. In incident-metrics/, map that WWID to the incident-time device name via"
+        echo "     node_disk_info{wwn=...} (label 'device'), since dm-*/sd* names may have"
+        echo "     changed since. Then read disk_io_time_by_device / disk_*_latency /"
+        echo "     disk_io_now for that device label."
+        echo "  3. In nodes/${INCIDENT_NODE}/multipath and kernel_red_flags.log /"
+        echo "     ${INCIDENT_NODE}_logs_journal, grep the WWID and each underlying sd* path"
+        echo "     for 'failing path'/'reinstating path' flap events."
+        echo ""
+    } > "${report}"
+
+    local sc driver vh mode va attached devlines line rpath rmm rkname rwwid rmpath rslaves netsrc
+    while read -r pvc; do
+        [[ -z "${pvc}" ]] && continue
+        pv="${PV_OF_PVC[${pvc}]}"
+        if [[ -z "${pv}" ]]; then
+            {
+                echo "PVC: ${pvc}"
+                echo "  (no bound PV found)"
+                echo ""
+            } >> "${report}"
+            printf '%s\t\t\t\t\t\t\t\t\t\t\t\t\t\n' "${pvc}" >> "${tsv}"
+            continue
+        fi
+
+        sc=$(timeout 30 /usr/bin/oc get pv "${pv}" --request-timeout=30s -o jsonpath='{.spec.storageClassName}' 2>/dev/null)
+        driver=$(timeout 30 /usr/bin/oc get pv "${pv}" --request-timeout=30s -o jsonpath='{.spec.csi.driver}' 2>/dev/null)
+        vh=$(timeout 30 /usr/bin/oc get pv "${pv}" --request-timeout=30s -o jsonpath='{.spec.csi.volumeHandle}' 2>/dev/null)
+        mode=$(timeout 30 /usr/bin/oc get pv "${pv}" --request-timeout=30s -o jsonpath='{.spec.volumeMode}' 2>/dev/null)
+        va=$(echo "${va_json}" | jq -r --arg pv "${pv}" --arg node "${INCIDENT_NODE}" \
+            '.items[]? | select(.spec.source.persistentVolumeName==$pv and .spec.nodeName==$node) | .metadata.name' 2>/dev/null | head -1)
+        attached=$(echo "${va_json}" | jq -r --arg pv "${pv}" --arg node "${INCIDENT_NODE}" \
+            '.items[]? | select(.spec.source.persistentVolumeName==$pv and .spec.nodeName==$node) | .status.attached' 2>/dev/null | head -1)
+
+        {
+            echo "PVC: ${pvc}"
+            echo "  PV:               ${pv}"
+            echo "  StorageClass:     ${sc:-<none>}"
+            echo "  CSI driver:       ${driver:-<non-csi>}"
+            echo "  volumeHandle:     ${vh:-<none>}"
+            echo "  volumeMode:       ${mode:-<none>}"
+            echo "  VolumeAttachment: ${va:-<none>} (attached=${attached:-unknown})"
+        } >> "${report}"
+
+        devlines="${DEVROWS[${pv}]}"
+        netsrc="${NETROWS[${pv}]}"
+        if [[ -n "${devlines}" ]]; then
+            echo "  Host block device(s) on ${INCIDENT_NODE} (names are point-in-time):" >> "${report}"
+            while IFS=$'\t' read -r _key rpath rmm rkname rwwid rmpath rslaves; do
+                [[ -z "${rkname}" ]] && continue
+                {
+                    if [[ -n "${rwwid}" ]]; then
+                        echo "    - WWID/UUID:      ${rwwid}   <- stable correlation key"
+                    else
+                        echo "    - WWID/UUID:      <unavailable — sd*/dm-* names below are the only handle>"
+                    fi
+                    echo "        kernel device:  ${rkname}  (${rpath}, ${rmm}) [as of collection]"
+                    [[ -n "${rmpath}" ]] && echo "        multipath name: ${rmpath}"
+                    if [[ -n "${rslaves}" ]]; then
+                        local -a _paths
+                        read -ra _paths <<< "${rslaves}"
+                        echo "        SCSI paths:     ${rslaves} (1:${#_paths[@]} multipath fan-out)"
+                    fi
+                    echo "        → metrics: node_disk_info{wwn=\"${rwwid:-?}\"} to find the"
+                    echo "          incident-time device label, then disk_io_time_by_device /"
+                    echo "          disk_*_latency for that device (dm-* aggregate + each sd* path)."
+                } >> "${report}"
+                printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                    "${pvc}" "${pv}" "${sc}" "${driver}" "${vh}" "${mode}" "${va}" "${attached}" \
+                    "${rkname}" "${rpath}" "${rmm}" "${rwwid}" "${rmpath}" "${rslaves}" >> "${tsv}"
+            done <<< "${devlines}"
+        elif [[ -n "${netsrc}" ]]; then
+            echo "  Network/file-backed volume (no host block device):" >> "${report}"
+            while IFS= read -r line; do
+                [[ -z "${line}" ]] && continue
+                echo "    - source: ${line}" >> "${report}"
+                printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\t%s\t\t\t\t\n' \
+                    "${pvc}" "${pv}" "${sc}" "${driver}" "${vh}" "${mode}" "${va}" "${attached}" "${line}" >> "${tsv}"
+            done <<< "${netsrc}"
+        else
+            if [[ -n "${NODE_GATHER_POD}" ]]; then
+                echo "  Host block device: NOT RESOLVED (volume may be detached, or CSI layout unrecognized)" >> "${report}"
+            else
+                echo "  Host block device: not resolved (node-gather pod unavailable)" >> "${report}"
+            fi
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\t\t\t\t\t\n' \
+                "${pvc}" "${pv}" "${sc}" "${driver}" "${vh}" "${mode}" "${va}" "${attached}" >> "${tsv}"
+        fi
+        echo "" >> "${report}"
+    done <<< "${pvcs}"
+
+    # Machine-readable JSON (one record per PVC/host-device pair)
+    jq -R -s '
+        split("\n") | map(select(length > 0)) | map(split("\t")) |
+        map({
+            pvc: .[0], pv: .[1], storageClass: .[2], csiDriver: .[3],
+            volumeHandle: .[4], volumeMode: .[5], volumeAttachment: .[6], attached: .[7],
+            hostDevice: {
+                kname: .[8], path: .[9], majorMinor: .[10], wwid: .[11],
+                multipathName: .[12],
+                underlyingPaths: (.[13] // "" | split(" ") | map(select(length > 0)))
+            }
+        })
+    ' "${tsv}" > "${json_out}" 2>/dev/null || echo "[]" > "${json_out}"
+
+    rm -f "${tsv}"
+    collected "storage device mapping: PVC/PV -> volumeHandle -> host block device (dm/sd/WWID)"
+    set -x
+}
+
 # --- Node Discovery via PromQL ---
 echo "Discovering node for VM ${VM} in namespace ${NS} at incident time..."
 
@@ -252,6 +534,14 @@ else
 fi
 
 wait
+
+# Map VM storage to host block devices while the node-gather pod is still alive
+# (needs on-node access to /dev, multipath, and the kubelet CSI publish paths).
+if check_timeout; then
+    collect_storage_device_mapping
+else
+    skipped "storage device mapping (timeout reached before collection)"
+fi
 
 # Clean up node-gather (runs now, disarm the EXIT trap)
 cleanup_node_gather
@@ -609,6 +899,8 @@ echo "  Kernel flags:   nodes/${INCIDENT_NODE}/kernel_red_flags.log"
 echo "  Cluster health: cluster-scoped-resources/{cluster_operators,nodes_overview,machineconfigpools,top_node}"
 echo "  VM/VMI:         namespaces/${NS}/kubevirt.io/"
 echo "  Storage chain:  PVCs, PVs, StorageClasses, DataVolumes, VolumeAttachments"
+echo "  Device mapping: namespaces/${NS}/vms/${VM}/storage-device-mapping.{txt,json}"
+echo "  Node devices:   nodes/${INCIDENT_NODE}/{block_devices,multipath,dev_disk_by_id,pv_device_resolution}"
 echo "  Metrics:        incident-metrics/"
 echo "  Pod logs:       namespaces/${NS}/core/pods/"
 if [[ -d "${BASE_COLLECTION_PATH}/namespaces/${NS}/vms/${VM}" ]]; then

--- a/collection-scripts/incident_metrics.conf
+++ b/collection-scripts/incident_metrics.conf
@@ -34,5 +34,15 @@ storage|pv_usage_pct|kubelet_volume_stats_used_bytes{namespace="$NS"} / kubelet_
 storage|volume_mount_duration|rate(storage_operation_duration_seconds_sum{operation_name="volume_mount",node="$NODE"}[5m]) / rate(storage_operation_duration_seconds_count{operation_name="volume_mount",node="$NODE"}[5m])|Average volume mount duration seconds
 storage|volume_access_control_duration|rate(storage_operation_duration_seconds_sum{operation_name="volume_apply_access_control",node="$NODE"}[5m]) / rate(storage_operation_duration_seconds_count{operation_name="volume_apply_access_control",node="$NODE"}[5m])|Average volume apply-access-control duration seconds
 
+# --- Per-device block I/O (node_exporter, keyed by kernel device name) ---
+# node_disk_info carries the device<->wwn/serial map AS SCRAPED at incident time, so the
+# point-in-time dm-*/sd* names in storage-device-mapping.txt can be tied back to the stable
+# WWID even if kernel device names changed between the incident and must-gather collection.
+storage|disk_info|node_disk_info{instance="$NODE"}|Block device identity (device<->wwn/serial/model) for stable WWID correlation
+storage|disk_io_time_by_device|rate(node_disk_io_time_seconds_total{instance="$NODE"}[5m])|Per-device I/O utilization (dm-* aggregate and each sd* path)
+storage|disk_read_latency|rate(node_disk_read_time_seconds_total{instance="$NODE"}[5m]) / clamp_min(rate(node_disk_reads_completed_total{instance="$NODE"}[5m]), 1)|Per-device average read latency seconds
+storage|disk_write_latency|rate(node_disk_write_time_seconds_total{instance="$NODE"}[5m]) / clamp_min(rate(node_disk_writes_completed_total{instance="$NODE"}[5m]), 1)|Per-device average write latency seconds
+storage|disk_io_now|node_disk_io_now{instance="$NODE"}|Per-device in-flight I/O operations (queue depth)
+
 # --- KubeVirt alerts ---
 alert|kubevirt_firing_alerts|ALERTS{alertstate="firing",kubernetes_operator_part_of="kubevirt"}|KubeVirt firing alerts at incident time

--- a/tests/validate_must_gather_test.go
+++ b/tests/validate_must_gather_test.go
@@ -1196,6 +1196,69 @@ var _ = Describe("validate the must-gather output", func() {
 			}
 		})
 
+		It("should map VM storage to host block devices", func() {
+			// Derive the VM name from the archive (vms/<vm>/), matching the other
+			// incident tests — the outer scope only exposes namespace and dir.
+			vmsBaseDir := path.Join(incidentDir, "namespaces", incidentNs, "vms")
+			vmEntries, err := os.ReadDir(vmsBaseDir)
+			if err != nil || len(vmEntries) == 0 {
+				logger.Printf("  no vms/ directory (VM may not have per-VM artifacts)")
+				return
+			}
+			incidentVM := vmEntries[0].Name()
+
+			vmDir := path.Join(vmsBaseDir, incidentVM)
+			mappingTxt := path.Join(vmDir, "storage-device-mapping.txt")
+			mappingJSON := path.Join(vmDir, "storage-device-mapping.json")
+
+			// The mapping is only produced when the VM has PVCs. Skip gracefully otherwise.
+			if _, err := os.Stat(mappingTxt); os.IsNotExist(err) {
+				logger.Printf("  no storage-device-mapping.txt (VM may not use persistent storage)")
+				return
+			}
+
+			info, statErr := os.Stat(mappingTxt)
+			Expect(statErr).ToNot(HaveOccurred(), "storage-device-mapping.txt should exist")
+			Expect(info.Size()).To(BeNumerically(">", 0), "storage-device-mapping.txt should not be empty")
+
+			// JSON must be present and parseable so downstream tooling can consume it.
+			data, err := os.ReadFile(mappingJSON)
+			Expect(err).ToNot(HaveOccurred(), "storage-device-mapping.json should exist")
+			var records []struct {
+				PVC          string `json:"pvc"`
+				PV           string `json:"pv"`
+				VolumeHandle string `json:"volumeHandle"`
+				HostDevice   struct {
+					Kname           string   `json:"kname"`
+					WWID            string   `json:"wwid"`
+					UnderlyingPaths []string `json:"underlyingPaths"`
+				} `json:"hostDevice"`
+			}
+			Expect(json.Unmarshal(data, &records)).To(Succeed(), "storage-device-mapping.json should be valid JSON")
+			logger.Printf("  storage-device-mapping records: %d", len(records))
+			for _, r := range records {
+				logger.Printf("    PVC %s -> PV %s -> handle=%q -> device=%q wwid=%q paths=%v",
+					r.PVC, r.PV, r.VolumeHandle, r.HostDevice.Kname, r.HostDevice.WWID, r.HostDevice.UnderlyingPaths)
+			}
+
+			// Node-side block inventory is best-effort (depends on the node-gather pod and
+			// storage backend); log what landed rather than failing on absence.
+			nodesBaseDir := path.Join(incidentDir, "nodes")
+			if nodeEntries, err := os.ReadDir(nodesBaseDir); err == nil {
+				for _, ne := range nodeEntries {
+					if !ne.IsDir() {
+						continue
+					}
+					nodeDir := path.Join(nodesBaseDir, ne.Name())
+					for _, f := range []string{"block_devices", "multipath", "dev_disk_by_id", "pv_device_resolution"} {
+						if fi, err := os.Stat(path.Join(nodeDir, f)); err == nil && fi.Size() > 0 {
+							logger.Printf("  node %s block inventory present: %s", ne.Name(), f)
+						}
+					}
+				}
+			}
+		})
+
 		It("should not leak ServiceAccount tokens or bearer credentials into the archive", func() {
 			// The Prometheus query functions use a ServiceAccount token. If set -x
 			// fires at the wrong time or stderr is misdirected, the Authorization


### PR DESCRIPTION
On shared hypervisor nodes, support could not easily map a VM's PV/PVC to a host WWID/dm-*/sd* device from the must-gather bundle alone, so node-wide storage events (multipath path flap, disk_io_util spikes) could not be attributed to the affected VM.

Add a storage device-mapping step to --vm-incident that resolves each VM volume to its physical device on the incident node:

  PVC -> PV -> csi.volumeHandle -> host dm-*/sd* -> WWID / multipath / SCSI paths

Resolution runs on the node via the kubelet CSI publish/staging path (block-mode) or the mount table (filesystem-mode), matched by device major:minor so it is independent of how the CSI driver named the device. Network/file-backed volumes report their source instead. Outputs namespaces/<ns>/vms/<vm>/storage-device-mapping.{txt,json} plus raw node inventory (block_devices, multipath, dev_disk_by_id, dmsetup, pv_device_resolution) under nodes/<node>/.

Handle the multipath 1:N semantics correctly: a dm-* device fans out over N SCSI paths, and dm-*/sd* kernel names are point-in-time (reassignable across rescan/reboot/live-migration). The report therefore anchors on the stable WWID and lists all underlying paths. To make the mapping usable historically:

  - add node_disk_info (device<->wwn/serial) plus per-device I/O util, read/write latency, and in-flight queue depth to incident_metrics.conf, so an incident-time device label can be tied back to the WWID even if kernel names changed before collection
  - extend KERNEL_REDFLAG_PATTERN with multipath/SCSI path-flap patterns (failing/reinstating path, blk_update_request, scsi_eh, rport blocked)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vm-incident: map PVC/PV volumeHandle to host block device (WWID-anchored)
```

